### PR TITLE
🎨 Palette: [UX improvement] add fuzzy match for invalid context_type

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,9 +4,12 @@
 ## 2024-05-18 - Improve configuration setting error reporting
 **Learning:** Returning a raw "Invalid key" or "Invalid log level" message forces users to look up documentation. A small fuzzy match with `difflib.get_close_matches` combined with a fallback list provides immediate, actionable feedback in the API response.
 **Action:** When returning validation errors for enumerated values (like settings keys or predefined constants), always try fuzzy matching to catch typos and include the full list of valid options as a fallback `suggestion`.
-## $(date +%Y-%m-%d) - Consistent Error Suggestions
+## 2026-07-08 - Consistent Error Suggestions
 **Learning:** Returning error messages without actionable next steps leaves the developer guessing what went wrong, which degrades Developer Experience (DX). In backend MCP servers, returning structured errors with `suggestion` strings is crucial.
 **Action:** When a tool returns an error structure (e.g., in `import_passport`), ensure it includes a `suggestion` key to guide the developer/agent on how to fix the issue.
 ## 2024-07-04 - Guarding difflib against non-string inputs
 **Learning:** `difflib.get_close_matches` throws an exception when the first argument is not iterable (e.g. integer or dict), crashing the MCP tool error handler. While `if action:` catches `None`, it doesn't protect against `0` or other non-string types.
 **Action:** Always wrap the first argument to `difflib.get_close_matches` with `str()` and use `is not None` when providing fuzzy matching suggestions for API inputs, to avoid unhandled TypeErrors.
+## 2026-07-08 - Context Type fuzzy matching error
+**Learning:** Returning a flat error when `context_type` is slightly misspelled causes friction. Fuzzy matching `context_type` and suggesting corrections improves DX by quickly guiding developers or agents to correct missing or invalid data.
+**Action:** Always provide fuzzy matched suggestions for `context_type` in capturing logic, utilizing `difflib.get_close_matches` along with the valid fallback options.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -977,15 +977,22 @@ async def _handle_capture(
     except ValueError as e:
         msg = str(e)
         if "context_type" in msg:
-            return _json(
-                {
-                    "error": msg,
-                    "valid_context_types": sorted(CONTEXT_TYPES),
-                    "suggestion": (
-                        f"Pick a context_type from {sorted(CONTEXT_TYPES)}."
-                    ),
-                }
+            closest = (
+                difflib.get_close_matches(str(context_type), list(CONTEXT_TYPES), n=1)
+                if context_type is not None
+                else []
             )
+            resp: dict[str, typing.Any] = {
+                "error": msg,
+                "valid_context_types": sorted(CONTEXT_TYPES),
+            }
+            if closest:
+                resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+            else:
+                resp["suggestion"] = (
+                    f"Available context_types are: {', '.join(sorted(CONTEXT_TYPES))}."
+                )
+            return _json(resp)
         return _json(
             {"error": msg, "suggestion": "Check payload length and constraints."}
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -958,3 +958,19 @@ class TestSpecializedTools:
             mock_handle.return_value = json.dumps({"status": "consolidated"})
             await consolidate_memories(category="test", ctx=ctx)
             mock_handle.assert_called_once()
+
+    async def test_handle_capture_invalid_context_type_fuzzy_match(self, ctx_with_db):
+        from mnemo_mcp.server import _handle_capture
+
+        ctx, db = ctx_with_db
+
+        res = json.loads(
+            await _handle_capture(
+                ctx=ctx,
+                text="Test capture",
+                context_type="skil",
+            )
+        )
+        assert "error" in res
+        assert "Unknown context_type" in res["error"]
+        assert "Did you mean 'skill'?" in res.get("suggestion", "")


### PR DESCRIPTION
Adds a micro-UX (DX) improvement to the memory capture endpoint. When `context_type` is provided but invalid (e.g., misspelled), it now uses `difflib.get_close_matches` against `CONTEXT_TYPES` to suggest a "Did you mean X?" message in the returned error payload, saving the user from having to look up the valid types.

---
*PR created automatically by Jules for task [10770192877258482223](https://jules.google.com/task/10770192877258482223) started by @n24q02m*