### PR TITLE
⚡ Bolt: Optimize JSON serialization overhead in MCP tool responses

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -367,8 +367,11 @@ def _get_ctx(ctx: Context | None) -> tuple[MemoryDB, str | None, int]:
 
 
 def _json(obj: object) -> str:
-    """Serialize to readable JSON."""
-    return json.dumps(obj, indent=2)
+    """Serialize to dense JSON."""
+    # Bolt Performance Optimization:
+    # Use dense formatting to minimize byte overhead, reduce serialization time,
+    # and lower token costs for LLM clients.
+    return json.dumps(obj, separators=(",", ":"))
 
 
 async def _maybe_include_setup_hint(result: dict) -> dict:

--- a/tests/test_security_log_level.py
+++ b/tests/test_security_log_level.py
@@ -77,6 +77,6 @@ async def test_log_level_valid_update(mock_dependencies):
                 result = await server.config(
                     action="set", key="log_level", value="DEBUG"
                 )
-                assert '"status": "updated"' in result
+                assert '"status":"updated"' in result
                 mock_logger.remove.assert_called_once()
                 mock_logger.add.assert_called_once()

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -619,10 +619,11 @@ class TestWarmupInitEmbeddingBackend:
 class TestJsonHelper:
     """Tests for the _json formatting helper."""
 
-    def test_json_indentation(self):
-        """Verify _json serializes with indent=2."""
+    def test_json_dense_formatting(self):
+        """Verify _json serializes with dense formatting."""
         data = {"a": 1, "b": [2, 3]}
         result = _json(data)
-        expected = json.dumps(data, indent=2)
+        expected = json.dumps(data, separators=(",", ":"))
         assert result == expected
-        assert "\n  " in result  # Check for 2-space indentation
+        assert "\n" not in result
+        assert " " not in result

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.4.0"
+version = "2.5.1b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
💡 What: Modified `_json` helper in `src/mnemo_mcp/server.py` to use dense formatting (`json.dumps(obj, separators=(',', ':'))`) instead of `indent=2`.
🎯 Why: MCP tool responses are consumed directly by LLMs, where token efficiency and parsing speed are critical. Human-readable indentation adds unnecessary byte overhead and consumes more tokens.
📊 Impact: Reduces response size directly scaling with payload complexity, saving token costs and marginal string creation/transport latency.
🔬 Measurement: Run the test suite (`uv run pytest`); unit tests in `tests/test_server_coverage.py` have been updated to assert dense formatting (no spaces or newlines).

---
*PR created automatically by Jules for task [7625741688890101384](https://jules.google.com/task/7625741688890101384) started by @n24q02m*