### PR TITLE
⚡ Bolt: Optimize JSON serialization density for MCP responses

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -367,8 +367,14 @@ def _get_ctx(ctx: Context | None) -> tuple[MemoryDB, str | None, int]:
 
 
 def _json(obj: object) -> str:
-    """Serialize to readable JSON."""
-    return json.dumps(obj, indent=2)
+    """Serialize to dense JSON.
+
+    # Bolt Performance Optimization:
+    # Use dense formatting with separators=(',', ':') instead of indent=2.
+    # This minimizes byte overhead, reduces serialization time, and lowers
+    # token costs for LLM clients processing the responses.
+    """
+    return json.dumps(obj, separators=(",", ":"))
 
 
 async def _maybe_include_setup_hint(result: dict) -> dict:

--- a/tests/test_security_log_level.py
+++ b/tests/test_security_log_level.py
@@ -77,6 +77,6 @@ async def test_log_level_valid_update(mock_dependencies):
                 result = await server.config(
                     action="set", key="log_level", value="DEBUG"
                 )
-                assert '"status": "updated"' in result
+                assert '"status":"updated"' in result
                 mock_logger.remove.assert_called_once()
                 mock_logger.add.assert_called_once()

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -620,9 +620,9 @@ class TestJsonHelper:
     """Tests for the _json formatting helper."""
 
     def test_json_indentation(self):
-        """Verify _json serializes with indent=2."""
+        """Verify _json serializes densely without indentation."""
         data = {"a": 1, "b": [2, 3]}
         result = _json(data)
-        expected = json.dumps(data, indent=2)
+        expected = json.dumps(data, separators=(",", ":"))
         assert result == expected
-        assert "\n  " in result  # Check for 2-space indentation
+        assert "\n" not in result  # Check for no indentation

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.4.0"
+version = "2.6.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
💡 What: Modified the `_json` helper to use dense formatting (`separators=(',', ':')`) rather than `indent=2` for all tool responses.
🎯 Why: MCP tool responses are consumed by LLMs. Extraneous whitespace (indentation and spaces after colons/commas) inflates the payload size, increasing network overhead and token costs when the LLM client parses the response.
📊 Impact: Reduces byte size and token consumption for all JSON responses, especially for large arrays returned by tools like `search_memory` or `list_memories`.
🔬 Measurement: Verified via unit tests (`uv run pytest`) that JSON payloads are correctly serialized without indentation, and that test assertions relying on exact string matches were updated accordingly.

---
*PR created automatically by Jules for task [14044722004116045003](https://jules.google.com/task/14044722004116045003) started by @n24q02m*