### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure file permissions with write_bytes

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2111,7 +2111,24 @@ async def _handle_config_export_passport(ctx: Context | None) -> str:
     out_dir = settings.get_data_dir()
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"passport-{int(__import__('time').time())}.mnemo"
-    await asyncio.to_thread(path.write_bytes, bundle)
+
+    def _secure_write_bytes(file_path: typing.Any, content: bytes) -> None:
+        import os
+        import stat
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        mode = stat.S_IRUSR | stat.S_IWUSR
+        fd = os.open(file_path, flags, mode)
+        try:
+            if os.name != "nt":
+                os.fchmod(fd, mode)
+        except OSError:
+            pass
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+
+    await asyncio.to_thread(_secure_write_bytes, path, bundle)
     return _json({"status": "exported", "path": str(path), "size": len(bundle)})
 
 

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -450,8 +450,25 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
     )
 
     if response.status_code == 200:
+
+        def _secure_write_bytes(file_path: Path, content: bytes) -> None:
+            import os
+            import stat
+
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            mode = stat.S_IRUSR | stat.S_IWUSR
+            fd = os.open(file_path, flags, mode)
+            try:
+                if os.name != "nt":
+                    os.fchmod(fd, mode)
+            except OSError:
+                pass
+            with os.fdopen(fd, "wb") as f:
+                f.write(content)
+
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(dest_path.write_bytes, response.content)
+        await asyncio.to_thread(_secure_write_bytes, dest_path, response.content)
         return True
 
     logger.error(f"Download failed ({response.status_code}): {response.text[:100]}")


### PR DESCRIPTION
**Vulnerability:** Sensitive files like `passport` bundles and Google Drive downloads were created using `Path.write_bytes()`, which doesn't enforce strict file permissions, potentially exposing them to unauthorized local users.
**Learning:** Basic file writing operations (`write_bytes()`, `write_text()`) create files with default umask permissions, leading to TOCTOU (Time-of-Check to Time-of-Use) vulnerabilities when dealing with sensitive data.
**Prevention:** Always use `os.open` with `os.O_CREAT | os.O_WRONLY | os.O_TRUNC` flags and `os.fchmod` to explicitly set `0600` (owner read/write) permissions when writing sensitive artifacts to disk.

---
*PR created automatically by Jules for task [17753223153831303450](https://jules.google.com/task/17753223153831303450) started by @n24q02m*