### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in file exports

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2074,7 +2074,23 @@ async def _handle_config_export_passport(ctx: Context | None) -> dict[str, typin
     out_dir = settings.get_data_dir()
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"passport-{int(__import__('time').time())}.mnemo"
-    await asyncio.to_thread(path.write_bytes, bundle)
+
+    def _write_secure_bundle(file_path, content: bytes) -> None:
+        import os
+        import stat
+
+        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        mode = stat.S_IRUSR | stat.S_IWUSR
+        fd = os.open(file_path, flags, mode)
+        try:
+            if os.name != "nt":
+                os.fchmod(fd, mode)
+        except OSError:
+            pass
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+
+    await asyncio.to_thread(_write_secure_bundle, path, bundle)
     return {"status": "exported", "path": str(path), "size": len(bundle)}
 
 

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -451,7 +451,23 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
 
     if response.status_code == 200:
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(dest_path.write_bytes, response.content)
+
+        def _write_secure(file_path: Path, content: bytes) -> None:
+            import os
+            import stat
+
+            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            mode = stat.S_IRUSR | stat.S_IWUSR
+            fd = os.open(file_path, flags, mode)
+            try:
+                if os.name != "nt":
+                    os.fchmod(fd, mode)
+            except OSError:
+                pass
+            with os.fdopen(fd, "wb") as f:
+                f.write(content)
+
+        await asyncio.to_thread(_write_secure, dest_path, response.content)
         return True
 
     logger.error(f"Download failed ({response.status_code}): {response.text[:100]}")


### PR DESCRIPTION
Replaced `Path.write_bytes` with secure file writing functions that use `os.open` and `os.fchmod` to enforce `0o600` permissions. This fixes a Time-Of-Check-To-Time-Of-Use (TOCTOU) vulnerability where sensitive files like passport bundles and database exports were created with permissive permissions, exposing them to unauthorized local users.

---
*PR created automatically by Jules for task [2384959836369877736](https://jules.google.com/task/2384959836369877736) started by @n24q02m*