### PR TITLE
fix: prevent information disclosure in gdrive merge failures

### DIFF
--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -604,10 +604,10 @@ async def sync_full(db: MemoryDB) -> dict:
             if import_result.get("imported", 0) > 0:
                 logger.info(f"Merged {import_result['imported']} memories from remote")
 
-        except Exception as e:
-            logger.error(f"Merge failed: {e}")
+        except Exception:
+            logger.exception("Merge failed")
             result["pull"] = {
-                "error": str(e),
+                "error": "Merge failed: internal error",
                 "suggestion": "Check remote database consistency and sync credentials.",
             }
         finally:


### PR DESCRIPTION
Replaces `str(e)` in the error response of `src/mnemo_mcp/sync/gdrive.py` with a static message `"Merge failed: internal error"` and logs the exception on the server instead, fixing an information disclosure vulnerability.

---
*PR created automatically by Jules for task [3438543228327000842](https://jules.google.com/task/3438543228327000842) started by @n24q02m*