### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in file permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@ recur. Its ledger entry was dated `2025-02-14`, more than a year off, and it was
 written at `##` where the entries around it were `###`, which filed a shipped fix
 under "Rejected". Date an entry from the commit that carries it, and check which
 section the heading level puts it in.
+
+## 2026-08-05 - File Descriptor Leaks and TOCTOU vulnerabilities in fchmod error handlers
+**Vulnerability:** In file creation paths (like `credential_state.py`, `server.py`, `gdrive.py`), the codebase used a pattern where `os.fchmod(fd, mode)` failures were caught with `except OSError: pass`, which silently skipped enforcing secure permissions and continued writing sensitive data with default permissions.
+**Learning:** Swallowing `OSError` exceptions when attempting to secure file permissions (e.g. `os.fchmod`) defeats the purpose of the security check and leads to Time-of-Check-to-Time-of-Use (TOCTOU) vulnerabilities, as sensitive files could be written with insecure permissions. Additionally, if an error occurred during or before the context manager (`with os.fdopen(fd, "w") as f:`), the raw file descriptor would not be explicitly closed, causing a resource leak.
+**Prevention:** Catch generic exceptions before the file is wrapped in a context manager, explicitly call `os.close(fd)`, and `raise` the exception to fail securely and prevent both TOCTOU vulnerabilities and file descriptor leaks.

--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -318,8 +318,9 @@ def store_for_sub(sub: str, config: dict[str, str]) -> None:
     try:
         if os.name != "nt":
             os.fchmod(fd, mode)
-    except OSError:
-        pass
+    except BaseException:
+        os.close(fd)
+        raise
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(config_json)
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2216,8 +2216,9 @@ async def _handle_config_export_passport(ctx: Context | None) -> dict[str, typin
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "wb") as f:
             f.write(content)
 

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -248,8 +248,9 @@ async def _save_folder_id(folder_name: str, folder_id: str) -> None:
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
 
@@ -463,8 +464,9 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
             try:
                 if os.name != "nt":
                     os.fchmod(fd, mode)
-            except OSError:
-                pass
+            except BaseException:
+                os.close(fd)
+                raise
             with os.fdopen(fd, "wb") as f:
                 f.write(content)
 


### PR DESCRIPTION
When creating sensitive files, `os.fchmod` failures were caught with `except OSError: pass`, which silently skipped enforcing secure permissions and continued writing sensitive data with default permissions. This commit fixes it by catching the exception, closing the file descriptor, and raising the error to fail securely, preventing TOCTOU vulnerabilities and file descriptor leaks.

---
*PR created automatically by Jules for task [1756715884390782631](https://jules.google.com/task/1756715884390782631) started by @n24q02m*