### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in file permission enforcement

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@ recur. Its ledger entry was dated `2025-02-14`, more than a year off, and it was
 written at `##` where the entries around it were `###`, which filed a shipped fix
 under "Rejected". Date an entry from the commit that carries it, and check which
 section the heading level puts it in.
+
+## 2026-08-09 - Avoid Swallowing os.fchmod Exceptions
+**Vulnerability:** In `src/mnemo_mcp/credential_state.py`, `src/mnemo_mcp/server.py` and `src/mnemo_mcp/sync/gdrive.py`, failures in `os.fchmod(fd, mode)` were being swallowed with an empty `except OSError: pass` block after creating a file with `os.open()`.
+**Learning:** Swallowing exceptions during file permission enforcement allows the program to silently fall back to insecure default file permissions. This introduces a Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability where sensitive files (like database backups, credentials, and token bundles) might become readable by other local users, and it also leaves the file descriptor open in the exception path, creating a resource leak.
+**Prevention:** Never swallow exceptions when enforcing secure file permissions on raw file descriptors. Instead, catch the exception, explicitly close the file descriptor with `os.close(fd)`, and re-raise the exception so the failure is properly handled by the caller without creating insecure files or leaking resources.

--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -312,14 +312,16 @@ def store_for_sub(sub: str, config: dict[str, str]) -> None:
     # SECURITY: Ensure the credential file is created with 0600 permissions
     # (read/write for owner only) to prevent unauthorized access by other
     # local users, mitigating a TOCTOU vulnerability from using write_text.
-    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    flags = os.O_CREAT | os.O_WRONLY
     mode = stat.S_IRUSR | stat.S_IWUSR
     fd = os.open(path, flags, mode)
     try:
         if os.name != "nt":
             os.fchmod(fd, mode)
-    except OSError:
-        pass
+        os.ftruncate(fd, 0)
+    except BaseException:
+        os.close(fd)
+        raise
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(config_json)
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2210,14 +2210,16 @@ async def _handle_config_export_passport(ctx: Context | None) -> dict[str, typin
         import stat
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        flags = os.O_CREAT | os.O_WRONLY
         mode = stat.S_IRUSR | stat.S_IWUSR
         fd = os.open(file_path, flags, mode)
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+            os.ftruncate(fd, 0)
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "wb") as f:
             f.write(content)
 

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -242,14 +242,16 @@ async def _save_folder_id(folder_name: str, folder_id: str) -> None:
         import stat
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        flags = os.O_CREAT | os.O_WRONLY
         mode = stat.S_IRUSR | stat.S_IWUSR
         fd = os.open(file_path, flags, mode)
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+            os.ftruncate(fd, 0)
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
 
@@ -457,14 +459,16 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
             import stat
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            flags = os.O_CREAT | os.O_WRONLY
             mode = stat.S_IRUSR | stat.S_IWUSR
             fd = os.open(file_path, flags, mode)
             try:
                 if os.name != "nt":
                     os.fchmod(fd, mode)
-            except OSError:
-                pass
+                os.ftruncate(fd, 0)
+            except BaseException:
+                os.close(fd)
+                raise
             with os.fdopen(fd, "wb") as f:
                 f.write(content)
 


### PR DESCRIPTION
Fixes a TOCTOU (Time-of-Check-to-Time-of-Use) vulnerability when enforcing file permissions on newly created sensitive files.

### Vulnerability

In several places (`credential_state.py`, `server.py`, `gdrive.py`), `os.fchmod(fd, mode)` was used to lock down file permissions after creating a file with `os.open()`. However, if `fchmod` failed, the exception was caught and silently ignored (`except OSError: pass`). 

This allowed the program to silently fall back to insecure default file permissions if `fchmod` was denied (e.g., if an attacker pre-created the file so the app doesn't own it). Furthermore, it truncated the file immediately upon opening, destroying the previous contents even if permission enforcement subsequently failed.

### Fix

*   Removed `os.O_TRUNC` from `os.open()` flags.
*   Added an explicit `os.ftruncate(fd, 0)` call *after* `os.fchmod(fd, mode)` succeeds, ensuring previous contents are only destroyed if the new permissions are successfully applied.
*   Added a `try...except BaseException` block around `fchmod` and `ftruncate`. If an exception occurs, the file descriptor is explicitly closed (`os.close(fd)`) and the exception is re-raised.
*   This matches the secure file creation pattern already used correctly in `src/mnemo_mcp/token_store.py`.

---
*PR created automatically by Jules for task [13720771552793340738](https://jules.google.com/task/13720771552793340738) started by @n24q02m*