### PR TITLE
fix: prevent TOCTOU vulnerability and fd leak by propagating fchmod errors

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@ recur. Its ledger entry was dated `2025-02-14`, more than a year off, and it was
 written at `##` where the entries around it were `###`, which filed a shipped fix
 under "Rejected". Date an entry from the commit that carries it, and check which
 section the heading level puts it in.
+
+## 2026-08-10 - TOCTOU and File Descriptor Leaks via Swallowed fchmod Errors
+**Vulnerability:** Several utility functions (`_write_secure_bytes` in `server.py` and `gdrive.py`, `_write_secure` in `gdrive.py`, and `store_for_sub` in `credential_state.py`) swallowed `OSError` exceptions from `os.fchmod`. Combined with `os.O_TRUNC` in `os.open`, this created a race condition where a file could be created and truncated securely but fail to apply secure permissions, leaving sensitive files (like database exports, passports, or configurations) readable by other users. Swallowing the exception also leaked the file descriptor because `os.close(fd)` was not called in the error path.
+**Learning:** Relying on `try: ... except OSError: pass` for `os.fchmod` on raw file descriptors defeats the purpose of creating secure files and introduces TOCTOU vulnerabilities and file descriptor leaks on POSIX systems.
+**Prevention:** Avoid swallowing `os.fchmod` errors. Ensure `os.O_TRUNC` is not used in `os.open`. Instead, use `os.fchmod(fd, mode)` followed by `os.ftruncate(fd, 0)`, and catch exceptions using `except BaseException: os.close(fd); raise` to ensure file descriptors are not leaked and insecure files are not written.

--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -312,14 +312,16 @@ def store_for_sub(sub: str, config: dict[str, str]) -> None:
     # SECURITY: Ensure the credential file is created with 0600 permissions
     # (read/write for owner only) to prevent unauthorized access by other
     # local users, mitigating a TOCTOU vulnerability from using write_text.
-    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    flags = os.O_CREAT | os.O_WRONLY
     mode = stat.S_IRUSR | stat.S_IWUSR
     fd = os.open(path, flags, mode)
     try:
         if os.name != "nt":
             os.fchmod(fd, mode)
-    except OSError:
-        pass
+        os.ftruncate(fd, 0)
+    except BaseException:
+        os.close(fd)
+        raise
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(config_json)
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2210,14 +2210,16 @@ async def _handle_config_export_passport(ctx: Context | None) -> dict[str, typin
         import stat
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        flags = os.O_CREAT | os.O_WRONLY
         mode = stat.S_IRUSR | stat.S_IWUSR
         fd = os.open(file_path, flags, mode)
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+            os.ftruncate(fd, 0)
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "wb") as f:
             f.write(content)
 

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -242,14 +242,16 @@ async def _save_folder_id(folder_name: str, folder_id: str) -> None:
         import stat
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        flags = os.O_CREAT | os.O_WRONLY
         mode = stat.S_IRUSR | stat.S_IWUSR
         fd = os.open(file_path, flags, mode)
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+            os.ftruncate(fd, 0)
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
 
@@ -457,14 +459,16 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
             import stat
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            flags = os.O_CREAT | os.O_WRONLY
             mode = stat.S_IRUSR | stat.S_IWUSR
             fd = os.open(file_path, flags, mode)
             try:
                 if os.name != "nt":
                     os.fchmod(fd, mode)
-            except OSError:
-                pass
+                os.ftruncate(fd, 0)
+            except BaseException:
+                os.close(fd)
+                raise
             with os.fdopen(fd, "wb") as f:
                 f.write(content)
 

--- a/tests/test_fchmod_swallow.py
+++ b/tests/test_fchmod_swallow.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_credential_state_store_for_sub_fchmod_propagates(tmp_path):
+    import mnemo_mcp.credential_state
+
+    with (
+        patch("mnemo_mcp.credential_state._sub_data_dir", return_value=tmp_path),
+        patch("mnemo_mcp.credential_state.os.name", "posix"),
+        patch("mnemo_mcp.credential_state.os.fchmod", side_effect=OSError("fchmod failed")),
+        pytest.raises(OSError, match="fchmod failed")
+    ):
+        mnemo_mcp.credential_state.store_for_sub("sub123", {"key": "val"})
+
+def test_gdrive_save_folder_id_fchmod_propagates(tmp_path):
+    import asyncio
+
+    from mnemo_mcp.sync.gdrive import _save_folder_id
+
+    with (
+        patch("mnemo_mcp.sync.gdrive.settings") as mock_settings,
+        patch("os.name", "posix"),
+        patch("os.fchmod", side_effect=OSError("fchmod failed")),
+        pytest.raises(OSError, match="fchmod failed")
+    ):
+        mock_settings.get_data_dir.return_value = tmp_path
+        asyncio.run(_save_folder_id("myfolder", "123"))
+
+def test_gdrive_download_file_fchmod_propagates(tmp_path):
+    import asyncio
+
+    from mnemo_mcp.sync.gdrive import _download_file
+
+    dest_path = tmp_path / "dest.bin"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"content"
+
+    with (
+        patch("mnemo_mcp.sync.gdrive._drive_request", return_value=mock_response),
+        patch("os.name", "posix"),
+        patch("os.fchmod", side_effect=OSError("fchmod failed")),
+        pytest.raises(OSError, match="fchmod failed")
+    ):
+        asyncio.run(_download_file({}, "file_id", dest_path))
+
+def test_server_write_secure_bytes_fchmod_propagates(tmp_path):
+    import asyncio
+
+    import mnemo_mcp.server
+    from mnemo_mcp.db import MemoryDB
+
+    mock_db = MagicMock(spec=MemoryDB)
+
+    with (
+        patch("mnemo_mcp.server.settings") as mock_settings,
+        patch("mnemo_mcp.server.os.name", "posix"),
+        patch("mnemo_mcp.server.os.fchmod", side_effect=OSError("fchmod failed")),
+        patch("mnemo_mcp.server._get_ctx", return_value=(mock_db, None, None)),
+        patch("mnemo_mcp.server._resolve_sync_passphrase", return_value="passphrase"),
+        patch("mnemo_mcp.server.build_full_bundle", return_value=b"bundle_data", create=True),
+        patch("mnemo_mcp.sync.delta.build_full_bundle", return_value=b"bundle_data"),
+        pytest.raises(OSError, match="fchmod failed")
+    ):
+        mock_settings.get_data_dir.return_value = tmp_path
+        asyncio.run(mnemo_mcp.server._handle_config_export_passport(None))

--- a/tests/test_fchmod_swallow.py
+++ b/tests/test_fchmod_swallow.py
@@ -9,10 +9,11 @@ def test_credential_state_store_for_sub_fchmod_propagates(tmp_path):
     with (
         patch("mnemo_mcp.credential_state._sub_data_dir", return_value=tmp_path),
         patch("mnemo_mcp.credential_state.os.name", "posix"),
-        patch("mnemo_mcp.credential_state.os.fchmod", side_effect=OSError("fchmod failed")),
-        pytest.raises(OSError, match="fchmod failed")
+        patch("os.fchmod", side_effect=OSError("fchmod failed")),
+        pytest.raises(OSError, match="fchmod failed"),
     ):
         mnemo_mcp.credential_state.store_for_sub("sub123", {"key": "val"})
+
 
 def test_gdrive_save_folder_id_fchmod_propagates(tmp_path):
     import asyncio
@@ -23,10 +24,11 @@ def test_gdrive_save_folder_id_fchmod_propagates(tmp_path):
         patch("mnemo_mcp.sync.gdrive.settings") as mock_settings,
         patch("os.name", "posix"),
         patch("os.fchmod", side_effect=OSError("fchmod failed")),
-        pytest.raises(OSError, match="fchmod failed")
+        pytest.raises(OSError, match="fchmod failed"),
     ):
         mock_settings.get_data_dir.return_value = tmp_path
         asyncio.run(_save_folder_id("myfolder", "123"))
+
 
 def test_gdrive_download_file_fchmod_propagates(tmp_path):
     import asyncio
@@ -43,9 +45,10 @@ def test_gdrive_download_file_fchmod_propagates(tmp_path):
         patch("mnemo_mcp.sync.gdrive._drive_request", return_value=mock_response),
         patch("os.name", "posix"),
         patch("os.fchmod", side_effect=OSError("fchmod failed")),
-        pytest.raises(OSError, match="fchmod failed")
+        pytest.raises(OSError, match="fchmod failed"),
     ):
         asyncio.run(_download_file({}, "file_id", dest_path))
+
 
 def test_server_write_secure_bytes_fchmod_propagates(tmp_path):
     import asyncio
@@ -57,13 +60,12 @@ def test_server_write_secure_bytes_fchmod_propagates(tmp_path):
 
     with (
         patch("mnemo_mcp.server.settings") as mock_settings,
-        patch("mnemo_mcp.server.os.name", "posix"),
-        patch("mnemo_mcp.server.os.fchmod", side_effect=OSError("fchmod failed")),
+        patch("os.name", "posix"),
+        patch("os.fchmod", side_effect=OSError("fchmod failed")),
         patch("mnemo_mcp.server._get_ctx", return_value=(mock_db, None, None)),
         patch("mnemo_mcp.server._resolve_sync_passphrase", return_value="passphrase"),
-        patch("mnemo_mcp.server.build_full_bundle", return_value=b"bundle_data", create=True),
         patch("mnemo_mcp.sync.delta.build_full_bundle", return_value=b"bundle_data"),
-        pytest.raises(OSError, match="fchmod failed")
+        pytest.raises(OSError, match="fchmod failed"),
     ):
         mock_settings.get_data_dir.return_value = tmp_path
         asyncio.run(mnemo_mcp.server._handle_config_export_passport(None))


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Various file-saving utility functions (`_write_secure_bytes` in `server.py` and `gdrive.py`, `_write_secure` in `gdrive.py`, and `store_for_sub` in `credential_state.py`) were insecurely swallowing `OSError` exceptions arising from `os.fchmod`. Combined with the use of `os.O_TRUNC` in the `os.open` flags, this allowed sensitive files (such as configurations and credentials) to be created and truncated securely but silently fail to apply restrictive `0600` permissions on POSIX systems. If `fchmod` failed, the file was left world-readable and the raw file descriptor was leaked because `os.close(fd)` was not called in the error path.
🎯 **Impact:** Authorized processes might successfully create files meant to be secure, but an inability to adjust permissions (e.g., due to filesystem constraints) would leave these files containing sensitive configurations, passwords, or exports completely accessible to unauthorized users on the same machine (TOCTOU vulnerability).
🔧 **Fix:** Refactored the file-saving utilities to follow the secure pattern established in `token_store.py`. Removed `os.O_TRUNC` from `os.open`, moved `os.ftruncate(fd, 0)` to immediately follow a successful `os.fchmod`, and replaced the silent error swallowing with an explicit `except BaseException: os.close(fd); raise` block to ensure both security and that no file descriptors are leaked.
✅ **Verification:** A new unit test suite (`tests/test_fchmod_swallow.py`) has been added to aggressively mock `os.fchmod` to throw an `OSError` and verify it is correctly propagated upstream rather than swallowed. All formatting, linting (Ruff), typing (Ty), and pytest suites run and pass.

---
*PR created automatically by Jules for task [6597486977696339608](https://jules.google.com/task/6597486977696339608) started by @n24q02m*