### PR TITLE
fix: resolve TOCTOU vulnerability in Google Drive sync token persistence

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@ recur. Its ledger entry was dated `2025-02-14`, more than a year off, and it was
 written at `##` where the entries around it were `###`, which filed a shipped fix
 under "Rejected". Date an entry from the commit that carries it, and check which
 section the heading level puts it in.
+
+## 2026-08-04 - TOCTOU Vulnerability in File Sync Persistence
+**Vulnerability:** In `src/mnemo_mcp/sync/gdrive.py`, functions persisting local credential/file state (`_write_secure` and `_write_secure_bytes`) used `os.O_TRUNC` with `os.open()`. This truncates the file immediately upon opening, creating a Time-of-Check to Time-of-Use (TOCTOU) window where the file content could be replaced before secure permissions (`os.fchmod`) are applied, and silently swallowing `OSError` left file descriptors open if the permission setting failed.
+**Learning:** Using `O_TRUNC` defeats the purpose of securely creating files with restricted permissions, as an attacker could access the briefly unprotected truncated file state. Swallowing the OS error creates an exposure where we write to an insecure file without knowing.
+**Prevention:** Avoid `os.O_TRUNC` in `os.open()` flags for sensitive files. Instead, use `os.open` with `os.O_CREAT | os.O_WRONLY`, apply permissions with `os.fchmod(fd, mode)`, and only *then* explicitly call `os.ftruncate(fd, 0)`. Always explicitly close the file descriptor (`os.close(fd)`) and re-raise the exception if the permission setting fails.

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -242,14 +242,16 @@ async def _save_folder_id(folder_name: str, folder_id: str) -> None:
         import stat
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        flags = os.O_CREAT | os.O_WRONLY
         mode = stat.S_IRUSR | stat.S_IWUSR
         fd = os.open(file_path, flags, mode)
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+            os.ftruncate(fd, 0)
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
 
@@ -457,14 +459,16 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
             import stat
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            flags = os.O_CREAT | os.O_WRONLY
             mode = stat.S_IRUSR | stat.S_IWUSR
             fd = os.open(file_path, flags, mode)
             try:
                 if os.name != "nt":
                     os.fchmod(fd, mode)
-            except OSError:
-                pass
+                os.ftruncate(fd, 0)
+            except BaseException:
+                os.close(fd)
+                raise
             with os.fdopen(fd, "wb") as f:
                 f.write(content)
 


### PR DESCRIPTION
In `src/mnemo_mcp/sync/gdrive.py`, functions persisting local credential/file state (`_write_secure` and `_write_secure_bytes`) used `os.O_TRUNC` with `os.open()`. This truncates the file immediately upon opening, creating a Time-of-Check to Time-of-Use (TOCTOU) window where the file content could be replaced before secure permissions (`os.fchmod`) are applied. Additionally, silently swallowing `OSError` left file descriptors open if the permission setting failed.

This commit resolves the issue by removing `os.O_TRUNC` from the `os.open()` flags. Instead, we use `os.open` with `os.O_CREAT | os.O_WRONLY`, apply permissions with `os.fchmod(fd, mode)`, and only *then* explicitly call `os.ftruncate(fd, 0)`. The code also explicitly closes the file descriptor (`os.close(fd)`) and re-raises the exception if the permission setting fails to avoid masking errors or leaking file descriptors.

---
*PR created automatically by Jules for task [13195527501316442217](https://jules.google.com/task/13195527501316442217) started by @n24q02m*