### PR TITLE
fix: 🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in file persistence

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@ recur. Its ledger entry was dated `2025-02-14`, more than a year off, and it was
 written at `##` where the entries around it were `###`, which filed a shipped fix
 under "Rejected". Date an entry from the commit that carries it, and check which
 section the heading level puts it in.
+
+## 2026-08-12 - TOCTOU Vulnerability in File Permissions Enforcement
+**Vulnerability:** Insecure file permission enforcement using `os.O_TRUNC` with `os.O_CREAT` and swallowing `os.fchmod` errors in `src/mnemo_mcp/server.py`, `src/mnemo_mcp/sync/gdrive.py`, and `src/mnemo_mcp/credential_state.py`.
+**Learning:** Swallowing `os.fchmod` errors allows sensitive files to be written with insecure permissions if `fchmod` fails. Using `os.O_TRUNC` with `os.O_CREAT` destroys existing file contents before permissions are verified.
+**Prevention:** Avoid `os.O_TRUNC` in open flags for sensitive files. Use `os.open` with `os.O_CREAT | os.O_WRONLY`. Do not swallow `os.fchmod` errors; catch the exception, close the file descriptor, and re-raise it. Then use `os.ftruncate(fd, 0)` after permissions are explicitly enforced.

--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -312,14 +312,16 @@ def store_for_sub(sub: str, config: dict[str, str]) -> None:
     # SECURITY: Ensure the credential file is created with 0600 permissions
     # (read/write for owner only) to prevent unauthorized access by other
     # local users, mitigating a TOCTOU vulnerability from using write_text.
-    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    flags = os.O_CREAT | os.O_WRONLY
     mode = stat.S_IRUSR | stat.S_IWUSR
     fd = os.open(path, flags, mode)
     try:
         if os.name != "nt":
             os.fchmod(fd, mode)
-    except OSError:
-        pass
+        os.ftruncate(fd, 0)
+    except BaseException:
+        os.close(fd)
+        raise
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(config_json)
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2210,14 +2210,16 @@ async def _handle_config_export_passport(ctx: Context | None) -> dict[str, typin
         import stat
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        flags = os.O_CREAT | os.O_WRONLY
         mode = stat.S_IRUSR | stat.S_IWUSR
         fd = os.open(file_path, flags, mode)
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+            os.ftruncate(fd, 0)
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "wb") as f:
             f.write(content)
 

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -242,14 +242,16 @@ async def _save_folder_id(folder_name: str, folder_id: str) -> None:
         import stat
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        flags = os.O_CREAT | os.O_WRONLY
         mode = stat.S_IRUSR | stat.S_IWUSR
         fd = os.open(file_path, flags, mode)
         try:
             if os.name != "nt":
                 os.fchmod(fd, mode)
-        except OSError:
-            pass
+            os.ftruncate(fd, 0)
+        except BaseException:
+            os.close(fd)
+            raise
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
 
@@ -457,14 +459,16 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
             import stat
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            flags = os.O_CREAT | os.O_WRONLY
             mode = stat.S_IRUSR | stat.S_IWUSR
             fd = os.open(file_path, flags, mode)
             try:
                 if os.name != "nt":
                     os.fchmod(fd, mode)
-            except OSError:
-                pass
+                os.ftruncate(fd, 0)
+            except BaseException:
+                os.close(fd)
+                raise
             with os.fdopen(fd, "wb") as f:
                 f.write(content)
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: TOCTOU (Time-of-Check to Time-of-Use) Vulnerability in File Permissions Enforcement. The code was using `os.O_TRUNC` in flags during file creation, and it also caught and silently ignored `OSError` if `os.fchmod` failed. This meant if a permission modification failed, sensitive data (like passport bundles or credentials) could be written to a file with insecure permissions.
🎯 Impact: Sensitive files (OAuth credentials, sync files) could be readable/writable by unauthorized local users.
🔧 Fix: Removed `os.O_TRUNC` from open flags. Handled `os.fchmod` properly by catching `BaseException`, closing the file descriptor, and raising the error to prevent silent continuation. Then, added `os.ftruncate(fd, 0)` only after permissions are securely enforced.
✅ Verification: Ran full `uv run ruff check`, `uv run ty check`, and `uv run pytest`. All checks passed. Added documentation to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1412581728957078141](https://jules.google.com/task/1412581728957078141) started by @n24q02m*