### PR TITLE
fix: harden secure local file writes

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -32,6 +32,8 @@ from loguru import logger
 from mcp_core.storage.backends import backend_from_env
 from mcp_core.storage.per_plugin_store import PerPluginStore
 
+from mnemo_mcp.secure_file import write_owner_only
+
 SERVER_NAME = "mnemo-mcp"
 
 # Grace window so the browser renders "Setup complete!" before the local spawn closes.
@@ -446,24 +448,10 @@ def store_for_sub(sub: str, config: dict[str, str]) -> None:
         store.save(config)
         return
 
-    import stat
-
     path = _sub_data_dir(sub) / "config.json"
     config_json = json.dumps(config)
 
-    # SECURITY: Ensure the credential file is created with 0600 permissions
-    # (read/write for owner only) to prevent unauthorized access by other
-    # local users, mitigating a TOCTOU vulnerability from using write_text.
-    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
-    mode = stat.S_IRUSR | stat.S_IWUSR
-    fd = os.open(path, flags, mode)
-    try:
-        if os.name != "nt":
-            os.fchmod(fd, mode)
-    except OSError:
-        pass
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(config_json)
+    write_owner_only(path, config_json.encode("utf-8"))
 
 
 def read_for_sub(sub: str) -> dict[str, str]:

--- a/src/mnemo_mcp/secure_file.py
+++ b/src/mnemo_mcp/secure_file.py
@@ -1,0 +1,34 @@
+"""Secure local-file persistence primitives."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+
+def write_owner_only(path: str | os.PathLike[str], content: bytes) -> None:
+    """Write bytes to a 0600 file without truncating before permission checks.
+
+    The file is opened without ``O_TRUNC`` so an existing file remains intact
+    when the POSIX permission check fails. Truncation happens only after the
+    descriptor has been restricted to the owner; all errors are propagated so
+    callers cannot mistake an insecure write for a successful save.
+    """
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    mode = stat.S_IRUSR | stat.S_IWUSR
+    fd = os.open(file_path, os.O_CREAT | os.O_WRONLY, mode)
+    handed_to_file = False
+    try:
+        if os.name != "nt":
+            os.fchmod(fd, mode)
+        os.ftruncate(fd, 0)
+        with os.fdopen(fd, "wb") as stream:
+            handed_to_file = True
+            stream.write(content)
+    except BaseException:
+        if not handed_to_file:
+            os.close(fd)
+        raise

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -26,6 +26,7 @@ from mcp.types import ToolAnnotations
 from mnemo_mcp.config import settings
 from mnemo_mcp.db import MemoryDB
 from mnemo_mcp.db_cf import MemoryDBCfBackend, open_memory_db
+from mnemo_mcp.secure_file import write_owner_only
 
 # Resolved via importlib.metadata (not ``from mnemo_mcp import __version__``)
 # to avoid a circular import: ``mnemo_mcp/__init__`` imports ``server.main``.
@@ -2489,23 +2490,7 @@ async def _handle_config_export_passport(ctx: Context | None) -> dict[str, typin
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"passport-{int(__import__('time').time())}.mnemo"
 
-    def _write_secure_bytes(file_path: typing.Any, content: bytes) -> None:
-        import os
-        import stat
-
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
-        mode = stat.S_IRUSR | stat.S_IWUSR
-        fd = os.open(file_path, flags, mode)
-        try:
-            if os.name != "nt":
-                os.fchmod(fd, mode)
-        except OSError:
-            pass
-        with os.fdopen(fd, "wb") as f:
-            f.write(content)
-
-    await asyncio.to_thread(_write_secure_bytes, path, bundle)
+    await asyncio.to_thread(write_owner_only, path, bundle)
     return {"status": "exported", "path": str(path), "size": len(bundle)}
 
 

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -39,6 +39,7 @@ from loguru import logger
 from mcp_core.auth import token_client_mismatch
 
 from mnemo_mcp.config import settings
+from mnemo_mcp.secure_file import write_owner_only
 from mnemo_mcp.sync.base import SyncBackend
 
 if TYPE_CHECKING:
@@ -238,20 +239,7 @@ async def _save_folder_id(folder_name: str, folder_id: str) -> None:
     path = settings.get_data_dir() / "sync_folder_ids.json"
 
     def _write_secure(file_path: Path, content: str) -> None:
-        import os
-        import stat
-
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
-        mode = stat.S_IRUSR | stat.S_IWUSR
-        fd = os.open(file_path, flags, mode)
-        try:
-            if os.name != "nt":
-                os.fchmod(fd, mode)
-        except OSError:
-            pass
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
+        write_owner_only(file_path, content.encode("utf-8"))
 
     async with _folder_id_disk_lock:
         data: dict[str, str] = {}
@@ -451,24 +439,7 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
     )
 
     if response.status_code == 200:
-
-        def _write_secure_bytes(file_path: Path, content: bytes) -> None:
-            import os
-            import stat
-
-            file_path.parent.mkdir(parents=True, exist_ok=True)
-            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
-            mode = stat.S_IRUSR | stat.S_IWUSR
-            fd = os.open(file_path, flags, mode)
-            try:
-                if os.name != "nt":
-                    os.fchmod(fd, mode)
-            except OSError:
-                pass
-            with os.fdopen(fd, "wb") as f:
-                f.write(content)
-
-        await asyncio.to_thread(_write_secure_bytes, dest_path, response.content)
+        await asyncio.to_thread(write_owner_only, dest_path, response.content)
         return True
 
     logger.error(f"Download failed ({response.status_code}): {response.text[:100]}")

--- a/tests/test_secure_file.py
+++ b/tests/test_secure_file.py
@@ -41,6 +41,7 @@ def test_windows_path_skips_posix_fchmod(tmp_path: Path):
     path = tmp_path / "secret.bin"
     with (
         patch("mnemo_mcp.secure_file.os.name", "nt"),
+        patch("mnemo_mcp.secure_file.Path", new=type(path)),
         patch("mnemo_mcp.secure_file.os.fchmod") as mock_fchmod,
     ):
         write_owner_only(path, b"windows-content")

--- a/tests/test_secure_file.py
+++ b/tests/test_secure_file.py
@@ -1,0 +1,49 @@
+"""Regression tests for owner-only file writes."""
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_write_owner_only_creates_restricted_file(tmp_path: Path):
+    from mnemo_mcp.secure_file import write_owner_only
+
+    path = tmp_path / "secret.bin"
+    write_owner_only(path, b"new-content")
+
+    assert path.read_bytes() == b"new-content"
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o777 == stat.S_IRUSR | stat.S_IWUSR
+
+
+def test_fchmod_failure_does_not_truncate_existing_file(tmp_path: Path):
+    from mnemo_mcp.secure_file import write_owner_only
+
+    path = tmp_path / "secret.bin"
+    path.write_bytes(b"previous-content")
+
+    if os.name == "nt":
+        pytest.skip("POSIX-only fchmod failure path")
+
+    with patch("mnemo_mcp.secure_file.os.fchmod", side_effect=OSError("not supported")):
+        with pytest.raises(OSError, match="not supported"):
+            write_owner_only(path, b"replacement")
+
+    assert path.read_bytes() == b"previous-content"
+
+
+def test_windows_path_skips_posix_fchmod(tmp_path: Path):
+    from mnemo_mcp.secure_file import write_owner_only
+
+    path = tmp_path / "secret.bin"
+    with (
+        patch("mnemo_mcp.secure_file.os.name", "nt"),
+        patch("mnemo_mcp.secure_file.os.fchmod") as mock_fchmod,
+    ):
+        write_owner_only(path, b"windows-content")
+
+    mock_fchmod.assert_not_called()
+    assert path.read_bytes() == b"windows-content"


### PR DESCRIPTION
## Summary

- centralize owner-only local-file persistence for credential, passport, and Google Drive cache writes
- apply permission checks before truncation and propagate write failures instead of treating insecure writes as successful
- add focused coverage for restricted permissions, failure preservation, and Windows behavior

## Validation

- uv run pytest -q — 1695 passed, 5 skipped, 78 deselected
- pre-commit — gitleaks, Ruff, format, ty, pytest, and file checks passed
- uv-lock-no-sources — local hook could not run because the Windows WSL environment has no /bin/bash
- git diff --check — passed

The deploy-only local configuration is intentionally not part of this PR.