### PR TITLE
fix: align cache recovery with fastretrieval

### DIFF
--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -7,7 +7,6 @@ async functions that return structured dicts for MCP tool responses.
 import asyncio
 import os
 import shutil
-import tempfile
 from pathlib import Path
 
 from loguru import logger
@@ -43,7 +42,10 @@ def _resolve_cache_dir() -> Path:
         )
         return Path(old)
 
-    return Path(tempfile.gettempdir()) / "fastretrieval_cache"
+    from fastretrieval.common.utils import define_cache_dir
+
+    # Keep cache recovery aligned with fastretrieval's own default path.
+    return define_cache_dir()
 
 
 def _validate_cloud_models(settings_obj) -> dict:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,6 +65,7 @@ _EXTRA_ENV_NAMES = {
     "USE_BUNDLED_GOOGLE_CLIENT",
     "MCP_RELAY_URL",
     "QWEN3_EMBED_CACHE_PATH",
+    "FASTRETRIEVAL_CACHE_PATH",
 }
 # litellm's per-provider endpoint override lives beside each provider key
 # (JINA_AI_API_KEY -> JINA_AI_API_BASE). Real developer shells do export these

--- a/tests/test_setup_tool_coverage.py
+++ b/tests/test_setup_tool_coverage.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest.mock import patch
 
 from mnemo_mcp.setup_tool import clear_model_cache
@@ -41,20 +40,20 @@ def test_clear_model_cache_respects_env_var(tmp_path):
         assert not model_cache.exists()
 
 
-def test_clear_model_cache_fallback_to_temp(tmp_path):
-    """Test clear_model_cache falls back to default temp dir if env var is missing."""
-    # We mock tempfile.gettempdir to point to our tmp_path to avoid polluting real temp
-    with patch("tempfile.gettempdir", return_value=str(tmp_path)):
-        # Ensure env var is NOT set
-        with patch.dict(os.environ, {}, clear=True):
-            model_name = "fallback/model"
-            safe_name = model_name.replace("/", "--")
+def test_clear_model_cache_fallback_to_fastretrieval_default(tmp_path):
+    """Use fastretrieval's default cache when no compatibility env is set."""
+    with patch.dict(os.environ, {}, clear=True):
+        model_name = "fallback/model"
+        safe_name = model_name.replace("/", "--")
+        default_cache_dir = tmp_path / "fastretrieval"
+        model_cache = default_cache_dir / f"models--{safe_name}"
+        model_cache.mkdir(parents=True)
 
-            # The expected fallback path is tmp_path / "fastretrieval_cache" / "models--fallback--model"
-            default_cache_dir = Path(tmp_path) / "fastretrieval_cache"
-            model_cache = default_cache_dir / f"models--{safe_name}"
-            model_cache.mkdir(parents=True)
-
+        with patch(
+            "fastretrieval.common.utils.define_cache_dir",
+            return_value=default_cache_dir,
+        ):
             result = clear_model_cache(model_name)
-            assert result == str(model_cache)
-            assert not model_cache.exists()
+
+        assert result == str(model_cache)
+        assert not model_cache.exists()


### PR DESCRIPTION
Follow-up to #1104. Aligns cache cleanup with fastretrieval.common.utils.define_cache_dir, preserves compatibility env handling, and adds coverage for FASTRETRIEVAL_CACHE_PATH. Local gate: 106 passed; Ruff, format, and ty passed.