### PR TITLE
feat: optimize database stats queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@ The proposed entry was headed `## $(date +%Y-%m-%d)`, a literal shell command wr
 
 ### 2026-08-01 - Unmeasured speedup figures on `update` (#1029)
 Same failure as the 2026-07-25 entry above, on the PR whose idea was taken into #1038. The Impact section claimed the removed `SELECT` was a throughput win, with no harness in the diff. Measured here at 4500 samples x 4 runs per branch: the `SELECT` is 12.6us inside a ~350us call, and the spread within a single branch (297-383us) is wider than the difference between branches (~2us median-of-medians). The change was worth making for atomicity, and #1038 stands on that argument alone. A profile that says a statement is removable does not say the removal is measurable.
+
+## 2024-05-14 - Optimize SQLite Aggregate Queries
+**Learning:** When computing overall aggregate statistics (like total COUNT or global MAX) alongside a grouped summary in SQLite, multiple database round-trips can be avoided.
+**Action:** Combine them into a single `GROUP BY` query (e.g., `SELECT category, COUNT(*), MAX(updated_at)`) and calculate the global totals in Python using `sum()` and `max()` on the returned rows. This avoids executing N distinct queries to the database.

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -1545,7 +1545,14 @@ class MemoryDB:
         ).fetchall()
 
         total = sum(r["cnt"] for r in categories) if categories else 0
-        last_updated = max((r["max_updated"] for r in categories if r["max_updated"] is not None), default=None) if categories else None
+        last_updated = (
+            max(
+                (r["max_updated"] for r in categories if r["max_updated"] is not None),
+                default=None,
+            )
+            if categories
+            else None
+        )
 
         return {
             "total_memories": total,

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -1538,18 +1538,14 @@ class MemoryDB:
         (``valid_to IS NULL``) -- superseded/soft-deleted history is not
         double-counted into totals or category breakdowns.
         """
-        total = self._conn.execute(
-            "SELECT COUNT(*) FROM memories WHERE valid_to IS NULL"
-        ).fetchone()[0]
-
+        # Bolt Performance Optimization: Combine total, categories, and last_updated into a single query
         categories = self._conn.execute(
-            "SELECT category, COUNT(*) as cnt FROM memories "
+            "SELECT category, COUNT(*) as cnt, MAX(updated_at) as max_updated FROM memories "
             "WHERE valid_to IS NULL GROUP BY category ORDER BY cnt DESC"
         ).fetchall()
 
-        last_updated = self._conn.execute(
-            "SELECT MAX(updated_at) FROM memories WHERE valid_to IS NULL"
-        ).fetchone()[0]
+        total = sum(r["cnt"] for r in categories) if categories else 0
+        last_updated = max((r["max_updated"] for r in categories if r["max_updated"] is not None), default=None) if categories else None
 
         return {
             "total_memories": total,


### PR DESCRIPTION
# Bolt Performance Optimization

### 💡 What:
Combined multiple distinct SQLite database queries within `db.stats()` into a single `GROUP BY` query, computing the global count and global max `updated_at` values in Python.

### 🎯 Why:
The original implementation executed 3 separate queries (counting total rows, grouping rows by category, and finding the maximum `updated_at`). This avoids scanning the database indexes three separate times and instead pulls all the required metrics in a single database round-trip.

### 📊 Impact:
Reduces database round-trips from 3 to 1 when calling `stats()`.

### 🔬 Measurement:
The optimization perfectly mimics the original data and all unit tests (including `test_stats`) pass seamlessly.

### 📖 Journal:
Added an entry to `.jules/bolt.md` documenting the optimization.

---
*PR created automatically by Jules for task [18271284469765679249](https://jules.google.com/task/18271284469765679249) started by @n24q02m*