### PR TITLE
fix: aggregate memory stats in one query

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -1538,18 +1538,16 @@ class MemoryDB:
         (``valid_to IS NULL``) -- superseded/soft-deleted history is not
         double-counted into totals or category breakdowns.
         """
-        total = self._conn.execute(
-            "SELECT COUNT(*) FROM memories WHERE valid_to IS NULL"
-        ).fetchone()[0]
-
         categories = self._conn.execute(
-            "SELECT category, COUNT(*) as cnt FROM memories "
+            "SELECT category, COUNT(*) as cnt, MAX(updated_at) as max_updated FROM memories "
             "WHERE valid_to IS NULL GROUP BY category ORDER BY cnt DESC"
         ).fetchall()
 
-        last_updated = self._conn.execute(
-            "SELECT MAX(updated_at) FROM memories WHERE valid_to IS NULL"
-        ).fetchone()[0]
+        total = sum(row["cnt"] for row in categories)
+        last_updated = max(
+            (row["max_updated"] for row in categories if row["max_updated"]),
+            default=None,
+        )
 
         return {
             "total_memories": total,

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -1545,7 +1545,11 @@ class MemoryDB:
 
         total = sum(row["cnt"] for row in categories)
         last_updated = max(
-            (row["max_updated"] for row in categories if row["max_updated"]),
+            (
+                row["max_updated"]
+                for row in categories
+                if row["max_updated"] is not None
+            ),
             default=None,
         )
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -331,6 +331,33 @@ class TestStats:
         s = tmp_db.stats()
         assert s["categories"] == {"x": 2, "y": 1}
 
+    def test_excludes_superseded_and_deleted_rows(self, tmp_db: MemoryDB):
+        tmp_db.add("active", category="active")
+        superseded_id = tmp_db.add("old", category="old")
+        tmp_db.update(superseded_id, category="current")
+        deleted_id = tmp_db.add("deleted", category="deleted")
+        assert tmp_db.delete(deleted_id) is True
+
+        stats = tmp_db.stats()
+
+        assert stats["total_memories"] == 2
+        assert stats["categories"] == {"active": 1, "current": 1}
+
+    def test_stats_uses_one_aggregate_query(self, tmp_db_with_data: MemoryDB):
+        statements: list[str] = []
+        tmp_db_with_data._conn.set_trace_callback(statements.append)
+        try:
+            tmp_db_with_data.stats()
+        finally:
+            tmp_db_with_data._conn.set_trace_callback(None)
+
+        select_statements = [
+            statement
+            for statement in statements
+            if statement.lstrip().upper().startswith("SELECT")
+        ]
+        assert len(select_statements) == 1
+
 
 class TestExportImport:
     def test_export_jsonl_format(self, tmp_db_with_data: MemoryDB):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -324,6 +324,17 @@ class TestStats:
         s = tmp_db.stats()
         assert s["last_updated"] is not None
 
+    def test_preserves_empty_imported_updated_at(self, tmp_db: MemoryDB):
+        result = tmp_db.import_jsonl(
+            json.dumps(
+                {"id": "empty-updated-at", "content": "imported", "updated_at": ""}
+            ),
+            mode="merge",
+        )
+
+        assert result["imported"] == 1
+        assert tmp_db.stats()["last_updated"] == ""
+
     def test_categories_count(self, tmp_db: MemoryDB):
         tmp_db.add("a", category="x")
         tmp_db.add("b", category="x")


### PR DESCRIPTION
## Tóm tắt

- Gộp COUNT, category counts và MAX(updated_at) vào một aggregate query trong `MemoryDB.stats()`.
- Giữ nguyên contract bitemporal: chỉ tính rows có `valid_to IS NULL`.
- Thêm regression cho empty DB, category counts, superseded/deleted rows và invariant chỉ một SELECT.
- Không mang `.jules`, `uv.lock` hoặc workflow collateral từ các PR bot.

## Verification

- Stats tests: 6 passed.
- Full suite trước format: 1700 passed, 5 skipped, 78 deselected.
- Ruff, ty, gitleaks và pre-commit hooks: PASS.

Human replacement for the duplicate implementation cluster represented by #1110 and #1112; those PRs remain open until this PR is reviewed and merged.
