### PR TITLE
fix: prevent KeyError string leakage in JSON response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@ recur. Its ledger entry was dated `2025-02-14`, more than a year off, and it was
 written at `##` where the entries around it were `###`, which filed a shipped fix
 under "Rejected". Date an entry from the commit that carries it, and check which
 section the heading level puts it in.
+
+## 2026-08-21 - Prevent Information Disclosure in Backend Sync Configuration Error Responses
+**Vulnerability:** Raw exception strings of `KeyError` (e.g., exposing the missing dictionary key which might contain configuration details) were returned directly in the JSON response of tool handlers (`sync_now`, `import_passport`) when a backend configuration was incomplete or missing.
+**Learning:** Returning dynamically generated exception strings for dictionary key misses (`str(e)` on `KeyError`) can leak internal implementation details or unexpected application state to the client, creating an Information Disclosure vulnerability.
+**Prevention:** Catch exceptions and return generic, statically defined error messages (e.g., `"backend configuration incomplete"`) in the JSON payload exposed to the client to avoid leaking `str(e)`.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2468,9 +2468,9 @@ async def _handle_config_sync_now(
 
         result = await sync_now(db, target, passphrase)
         return {"backend": target, **result}
-    except KeyError as e:
+    except KeyError:
         return {
-            "error": str(e),
+            "error": "backend configuration incomplete",
             "suggestion": "Check if backend configuration is complete.",
         }
     except Exception:
@@ -2529,9 +2529,9 @@ async def _handle_config_import_passport(
 
         backend = get_backend(target)
         bundle = await backend.pull(sequence=None)
-    except KeyError as e:
+    except KeyError:
         return {
-            "error": str(e),
+            "error": "backend configuration incomplete",
             "suggestion": "Ensure the specified backend is properly configured.",
         }
     except Exception:

--- a/tests/test_passport_actions.py
+++ b/tests/test_passport_actions.py
@@ -131,7 +131,7 @@ async def test_sync_now_unknown_backend(
     raw = await _handle_config_sync_now(ctx, backend="nonexistent")
     payload = raw
     assert "error" in payload
-    assert "nonexistent" in payload["error"]
+    assert "backend configuration incomplete" in payload["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Disclosure. `KeyError` exception strings, which expose missing dictionary keys, were being returned directly in JSON responses for `config(action="sync_now")` and `config(action="import_passport")`.
🎯 Impact: A malicious client or unauthorized observer could learn internal configuration structures or state details (such as missing env vars or config keys) intended to remain serverside, aiding in planning further attacks.
🔧 Fix: Replaced `str(e)` in the `KeyError` exception block with a generic, static `"backend configuration incomplete"` error message, preventing the leakage. Updated the tests to match this new string.
✅ Verification: Ran `uv run pytest tests/test_passport_actions.py -k test_sync_now_unknown_backend` to verify the error response matches the generic string.

---
*PR created automatically by Jules for task [3424439987837031819](https://jules.google.com/task/3424439987837031819) started by @n24q02m*