### PR TITLE
feat: add fuzzy matching to list category fallback suggestion

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,7 @@ reviewable surface here is -- the `error`, `suggestion` and `note` strings in
 `src/mnemo_mcp/server.py` and the tool docs under `src/mnemo_mcp/docs/` -- and
 that a decision to change nothing belongs in this file as an entry. Read this
 file before opening anything against this repository.
+
+## 2026-08-21 - Thread-safe SQLite execution in asyncio
+**Learning:** Wrapping SQLite connection calls like `db._conn.execute(...)` inside `asyncio.to_thread(...)` triggers `sqlite3.ProgrammingError` due to thread locality rules in Python's sqlite3 module.
+**Action:** When executing lightweight read queries on an existing connection within an async context, do so directly on the event loop (e.g., `valid_categories = [row[0] for row in db._conn.execute(...)]`) rather than spawning a thread.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -937,9 +937,26 @@ async def _handle_list(
     }
     if len(results) == 0:
         if category:
-            response["suggestion"] = (
-                f"No memories found in category '{category}'. Use action='list' without a category to see all, or action='add' to create some!"
+            valid_categories = [
+                row[0]
+                for row in db._conn.execute(
+                    "SELECT DISTINCT category FROM memories WHERE category IS NOT NULL"
+                ).fetchall()
+            ]
+            closest = (
+                difflib.get_close_matches(str(category), valid_categories, n=1)
+                if valid_categories and category is not None
+                else []
             )
+
+            if closest:
+                response["suggestion"] = (
+                    f"No memories found in category '{category}'. Did you mean '{closest[0]}'?"
+                )
+            else:
+                response["suggestion"] = (
+                    f"No memories found in category '{category}'. Use action='list' without a category to see all, or action='add' to create some!"
+                )
         else:
             response["suggestion"] = (
                 "No memories found. Use action='add' to create some!"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -996,3 +996,28 @@ class TestSpecializedTools:
             mock_handle.return_value = json.dumps({"status": "consolidated"})
             await consolidate_memories(category="test", ctx=ctx)
             mock_handle.assert_called_once()
+
+
+class TestMemoryListFuzzy:
+    async def test_list_fuzzy_suggestion(self, ctx_with_db):
+        from mnemo_mcp.server import memory
+
+        ctx, db = ctx_with_db
+        db.add("content1", category="work")
+        db.add("content2", category="personal")
+
+        # Test exact match not returning suggestion (assuming results > 0)
+        result = await memory(action="list", category="work", ctx=ctx)
+        assert result["count"] == 1
+        assert "suggestion" not in result
+
+        # Test fuzzy match
+        result = await memory(action="list", category="wor", ctx=ctx)
+        assert result["count"] == 0
+        assert "Did you mean 'work'?" in result["suggestion"]
+
+        # Test no fuzzy match
+        result = await memory(action="list", category="zzzzzzz", ctx=ctx)
+        assert result["count"] == 0
+        assert "Did you mean" not in result["suggestion"]
+        assert "Use action='list' without a category to see all" in result["suggestion"]


### PR DESCRIPTION
This PR improves the Developer Experience (DX) for the `list` tool. When a user provides a `category` parameter that yields zero results, the tool will now fetch the distinct list of existing categories from the database and perform a fuzzy match against the user's input. If a close match is found (e.g. they typed "wor" instead of "work"), the `suggestion` field in the response will offer the correction: "Did you mean 'work'?".

This applies the UX learnings from `palette.md` directly to the domain data.

---
*PR created automatically by Jules for task [15412412668239707155](https://jules.google.com/task/15412412668239707155) started by @n24q02m*