### PR TITLE
feat: add actionable suggestion to backfill_embeddings error response

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,7 @@ reviewable surface here is -- the `error`, `suggestion` and `note` strings in
 `src/mnemo_mcp/server.py` and the tool docs under `src/mnemo_mcp/docs/` -- and
 that a decision to change nothing belongs in this file as an entry. Read this
 file before opening anything against this repository.
+
+## 2026-08-23 - Add suggestions to missing errors in backend MCP
+**Learning:** In backend MCP servers where no UI is present, the API error response *is* the UX surface. Missing a `suggestion` key in structured dictionary error responses (such as "No embedding backend is configured") leaves the caller without actionable next steps. This degrades Developer Experience (DX) because the caller has to guess how to fix the issue.
+**Action:** When auditing or implementing API endpoints that return a structured dictionary containing an `error` key, always ensure that a corresponding `suggestion` key is provided to guide the caller on how to resolve the issue.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2062,6 +2062,7 @@ async def _handle_config_backfill(
         return {
             "status": "unavailable",
             "error": "No embedding backend is configured for the current subject.",
+            "suggestion": "Run the setup flow or provide API keys via environment variables to configure an embedding backend.",
             "scanned": 0,
             "embedded": 0,
             "skipped": 0,

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -247,6 +247,7 @@ class TestConfigSync:
         assert result == {
             "status": "unavailable",
             "error": "No embedding backend is configured for the current subject.",
+            "suggestion": "Run the setup flow or provide API keys via environment variables to configure an embedding backend.",
             "scanned": 0,
             "embedded": 0,
             "skipped": 0,


### PR DESCRIPTION
💡 **What**: Added a `suggestion` key to the structured JSON error returned by the `backfill_embeddings` action in the `config` tool when an embedding backend is missing.

🎯 **Why**: In a backend MCP server without a UI, the API error response *is* the UX surface. Returning error messages without actionable next steps leaves the developer guessing what went wrong, which degrades Developer Experience (DX). This ensures the error response guides the developer on how to fix the issue.

📸 **Before/After**:
*Before:*
```json
{
  "status": "unavailable",
  "error": "No embedding backend is configured for the current subject.",
  "scanned": 0, ...
}
```
*After:*
```json
{
  "status": "unavailable",
  "error": "No embedding backend is configured for the current subject.",
  "suggestion": "Run the setup flow or provide API keys via environment variables to configure an embedding backend.",
  "scanned": 0, ...
}
```

♿ **Accessibility**: Improves DX and self-service troubleshooting capability.

🎨 *Palette*, painting small strokes of UX excellence!

---
*PR created automatically by Jules for task [13280644967836827217](https://jules.google.com/task/13280644967836827217) started by @n24q02m*