### PR TITLE
fix: align mnemo retrieval contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # SQLite vector search
     "sqlite-vec",
     # Local ONNX embedding (auto-fallback when no cloud API)
-    "fastretrieval>=1.0.1",
+    "fastretrieval>=1.1.0b1,<2",
     # 1.19.0 ships mcp_core.cli's argument-spec extra subcommand
     # support ((configure, handler) tuples) this repo's cli.py auth
     # subcommand consumes. 1.20.0b2 fixes build_cli's `config`/`doctor`

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/mnemo-mcp",
-  "description": "Persistent AI memory with hybrid search (FTS5 + semantic) and cross-machine sync.",
+  "description": "Persistent AI memory with hybrid search and embedded sync. Open, free, unlimited.",
   "repository": {
     "url": "https://github.com/n24q02m/mnemo-mcp.git",
     "source": "github"

--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -22,7 +22,7 @@ Active actions: `status`, `sync`, `set`, `warmup`, `setup_sync`,
 
 ### `status` - Show current configuration
 
-Returns database stats, embedding model info, and sync status.
+Returns database stats, the resolved embedding identity, dimensions, availability, and sync status.
 
 **Parameters:** None
 
@@ -31,7 +31,7 @@ Returns database stats, embedding model info, and sync status.
   `cf-d1:<base-url>` when `MEMORY_DB_BACKEND=cf-d1`
 - `total_memories`: Total memory count
 - `categories`: Memory count by category
-- `embedding`: Model name, dimensions, availability
+- `embedding`: Exact resolved model identity (local model id or cloud candidate), storage dimensions, and availability. FTS-only/unavailable state is represented by a null model.
 - `sync`: Enabled, provider, folder, interval
 
 ### `sync` - Trigger manual sync

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -175,7 +175,7 @@ async def _init_embedding_backend(
                     f"Embedding: local {local_model} "
                     f"(native={native_dims}, stored={embedding_dims})"
                 )
-                ctx["embedding_model"] = "__local__"
+                ctx["embedding_model"] = local_model
                 ctx["embedding_dims"] = embedding_dims
             else:
                 logger.error("Local embedding model not available")

--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -42,9 +42,9 @@ def _resolve_cache_dir() -> Path:
         )
         return Path(old)
 
-    from fastretrieval.common.utils import define_cache_dir
+    from fastretrieval import define_cache_dir
 
-    # Keep cache recovery aligned with fastretrieval's own default path.
+    # Keep cache recovery aligned with fastretrieval's public API and default path.
     return define_cache_dir()
 
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -179,7 +179,7 @@ async def test_lifespan_local_backend_explicit(
     server = MagicMock()
     async with lifespan(server) as ctx:
         await _settle_background_init()
-        assert ctx["embedding_model"] == "__local__"
+        assert ctx["embedding_model"] == "local-model"
         assert ctx["embedding_dims"] == 768  # Default for stored
 
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -518,7 +518,7 @@ class TestInitEmbeddingBackendCandidate:
         ctx: dict = {"embedding_model": None, "embedding_dims": 768}
         await _init_embedding_backend("local", ctx)
 
-        assert ctx == {"embedding_model": "__local__", "embedding_dims": 384}
+        assert ctx == {"embedding_model": "local/m", "embedding_dims": 384}
 
 
 class TestCustomEmbeddingRegistration:
@@ -847,7 +847,7 @@ class TestWarmupInitEmbeddingBackend:
         await _init_embedding_backend("local", ctx)
 
         mock_init.assert_called_once_with("local", "local/m")
-        assert ctx["embedding_model"] == "__local__"
+        assert ctx["embedding_model"] == "local/m"
 
     @patch("mnemo_mcp.server._maybe_register_custom_embed")
     @patch(

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -55,6 +55,29 @@ class TestClearModelCache:
 
         assert result is None
 
+    def test_resolve_cache_dir_uses_fastretrieval_public_api(
+        self, tmp_path, monkeypatch
+    ):
+        import fastretrieval
+
+        from mnemo_mcp import setup_tool
+
+        public_cache = tmp_path / "public"
+        monkeypatch.delenv("FASTRETRIEVAL_CACHE_PATH", raising=False)
+        monkeypatch.delenv("QWEN3_EMBED_CACHE_PATH", raising=False)
+
+        public_define = MagicMock(return_value=public_cache)
+        monkeypatch.setattr(
+            fastretrieval, "define_cache_dir", public_define, raising=False
+        )
+        monkeypatch.setattr(
+            "fastretrieval.common.utils.define_cache_dir",
+            MagicMock(side_effect=AssertionError("private fastretrieval import used")),
+        )
+
+        assert setup_tool._resolve_cache_dir() == public_cache
+        public_define.assert_called_once_with()
+
 
 class TestValidateCloudModels:
     """_validate_cloud_models checks cloud embedding availability."""

--- a/tests/test_setup_tool_coverage.py
+++ b/tests/test_setup_tool_coverage.py
@@ -50,7 +50,7 @@ def test_clear_model_cache_fallback_to_fastretrieval_default(tmp_path):
         model_cache.mkdir(parents=True)
 
         with patch(
-            "fastretrieval.common.utils.define_cache_dir",
+            "fastretrieval.define_cache_dir",
             return_value=default_cache_dir,
         ):
             result = clear_model_cache(model_name)

--- a/uv.lock
+++ b/uv.lock
@@ -535,7 +535,7 @@ server = [
 
 [[package]]
 name = "fastretrieval"
-version = "1.0.1"
+version = "1.1.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -546,9 +546,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/35/2a91b42d6b9784ee620d4c75bd2abadbcbd3cf304dcb0a41f5a3a22ee0ba/fastretrieval-1.0.1.tar.gz", hash = "sha256:a1d766e1c1471347ba830c4a7f280ed7b0ff86fbc48425ac457b7b9d8d0e5783", size = 330230, upload-time = "2026-08-14T16:58:25.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2b/00cccf6ead62dc473fb3eccfccd222ca9f481dc85acacb568f49700d159e/fastretrieval-1.1.0b1.tar.gz", hash = "sha256:f5d0609d8255bb66647b65071c802af7401840ba6fedd0d39f93b477fba9722e", size = 330569, upload-time = "2026-08-22T12:47:25.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/94/28ba6e0d86b4b8bb0f2a687d5669bd3c6adb7c3346d6e80431fb66ba6c2d/fastretrieval-1.0.1-py3-none-any.whl", hash = "sha256:902851b02c6b1ffefc66aa63c7976a2226696d7ea2b43b9ec471029e97e58892", size = 144199, upload-time = "2026-08-14T16:58:24.195Z" },
+    { url = "https://files.pythonhosted.org/packages/51/df/bc661390b5a1f06ec476ee23e0e9e848f865b3e80543fcb74e5bf0a254b5/fastretrieval-1.1.0b1-py3-none-any.whl", hash = "sha256:a741bb849e7324d0e11d07b23237b278e45b294c1770ef9a036a77310ebb6bad", size = 144434, upload-time = "2026-08-22T12:47:24.442Z" },
 ]
 
 [[package]]
@@ -1130,7 +1130,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.69" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "fastmcp", specifier = ">=3.4.7,<4" },
-    { name = "fastretrieval", specifier = ">=1.0.1" },
+    { name = "fastretrieval", specifier = ">=1.1.0b1,<2" },
     { name = "httpx" },
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },


### PR DESCRIPTION
## Summary
- require the published `fastretrieval>=1.1.0b1,<2` contract and lock exact 1.1.0b1
- consume `define_cache_dir` only from the public package root
- preserve exact configured local embedding identity in status and align docs/registry metadata

## Verification
- `uv lock --locked`
- `uv run pytest tests -k "embedding or retrieval or setup or model" -q` — 316 passed
- real stdio MCP add/search smoke — 1 passed

Stable promotion is intentionally out of scope.