### PR TITLE
fix: document mnemo authority and retrieval flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,11 +84,11 @@ Khong co prefix (khac voi cac project khac):
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
 - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
-- `EMBEDDING_DIMS` -- default 768 (0 = auto)
+- `EMBEDDING_DIMS` -- local default 768 when `0 = auto`; the hosted Cloudflare profile uses 1536 for the active Vectorize index.
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Router auto-detect cu "Jina > Gemini > OpenAI > Cohere" da bo.
-- `SYNC_ENABLED` -- `true`/`false`, default true
-- `GOOGLE_DRIVE_CLIENT_ID` -- OAuth client ID (required for sync)
-- `SYNC_FOLDER` -- Google Drive folder name (default: `mnemo-mcp`)
+- `SYNC_ENABLED` -- `true`/`false`, default true for local/self-host; the production Cloudflare deployment pins `false`.
+- `GOOGLE_DRIVE_CLIENT_ID` -- OAuth client ID for optional local/self-host passport sync
+- `SYNC_FOLDER` -- Google Drive folder name for optional local/self-host sync (default: `mnemo-mcp`)
 - `SYNC_INTERVAL` -- seconds (0 = manual only, default: 300)
 - `RERANK_ENABLED` -- `true`/`false`, default true
 - `RERANK_TOP_N` -- so ket qua rerank giu lai (default: 10)
@@ -122,8 +122,24 @@ Khong co prefix (khac voi cac project khac):
 ## Embedding architecture
 
 1. **Cloud** (`EMBEDDING_MODELS` chain) -- thu lan luot theo thu tu, fallback qua litellm.
-2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available
-- Tat ca embeddings luu tai 768 dims. Doi embedding MODEL = doi vector space -> B2 identity guard chan boot (set REINDEX_ON_MODEL_CHANGE=true de re-embed). 768-dim chung chi giu table khong vo; KHONG cho mix vector 2 model khac nhau (cung dims van rac search).
+2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available.
+
+Local SQLite uses the local default width (768 unless a provider reports another
+dimension). The hosted Cloudflare profile is pinned to the active 1536-dimension
+Vectorize index; `REINDEX_ON_MODEL_CHANGE=true` clears stale vector state before
+the next embedding pass. Never mix vectors from different model identities.
+
+## Storage authority and sync boundary
+
+- **Cloudflare deployed mode**: D1 is authoritative for memory rows and FTS5,
+  Vectorize is authoritative for dense vectors, and KV stores encrypted
+  per-sub credentials. `SYNC_ENABLED=false` disables legacy DB-file Google Drive
+  sync on the production deployment.
+- **Local/self-host mode**: SQLite remains local authority and passport sync
+  (Google Drive Device Code OAuth or S3-compatible storage) is opt-in.
+- Drive inventory/cleanup is an independent safety lane: exact root, recursive
+  manifest, durable backup/restore proof, and exact-ID post-verify are required
+  before any mutation.
 
 ## CD Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,11 @@ Khong co prefix (khac voi cac project khac):
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
 - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
-- `EMBEDDING_DIMS` -- default 768 (0 = auto)
+- `EMBEDDING_DIMS` -- local default 768 when `0 = auto`; the hosted Cloudflare profile uses 1536 for the active Vectorize index.
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Router auto-detect cu "Jina > Gemini > OpenAI > Cohere" da bo.
-- `SYNC_ENABLED` -- `true`/`false`, default true
-- `GOOGLE_DRIVE_CLIENT_ID` -- OAuth client ID (required for sync)
-- `SYNC_FOLDER` -- Google Drive folder name (default: `mnemo-mcp`)
+- `SYNC_ENABLED` -- `true`/`false`, default true for local/self-host; the production Cloudflare deployment pins `false`.
+- `GOOGLE_DRIVE_CLIENT_ID` -- OAuth client ID for optional local/self-host passport sync
+- `SYNC_FOLDER` -- Google Drive folder name for optional local/self-host sync (default: `mnemo-mcp`)
 - `SYNC_INTERVAL` -- seconds (0 = manual only, default: 300)
 - `RERANK_ENABLED` -- `true`/`false`, default true
 - `RERANK_TOP_N` -- so ket qua rerank giu lai (default: 10)
@@ -122,8 +122,24 @@ Khong co prefix (khac voi cac project khac):
 ## Embedding architecture
 
 1. **Cloud** (`EMBEDDING_MODELS` chain) -- thu lan luot theo thu tu, fallback qua litellm.
-2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available
-- Tat ca embeddings luu tai 768 dims. Doi embedding MODEL = doi vector space -> B2 identity guard chan boot (set REINDEX_ON_MODEL_CHANGE=true de re-embed). 768-dim chung chi giu table khong vo; KHONG cho mix vector 2 model khac nhau (cung dims van rac search).
+2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available.
+
+Local SQLite uses the local default width (768 unless a provider reports another
+dimension). The hosted Cloudflare profile is pinned to the active 1536-dimension
+Vectorize index; `REINDEX_ON_MODEL_CHANGE=true` clears stale vector state before
+the next embedding pass. Never mix vectors from different model identities.
+
+## Storage authority and sync boundary
+
+- **Cloudflare deployed mode**: D1 is authoritative for memory rows and FTS5,
+  Vectorize is authoritative for dense vectors, and KV stores encrypted
+  per-sub credentials. `SYNC_ENABLED=false` disables legacy DB-file Google Drive
+  sync on the production deployment.
+- **Local/self-host mode**: SQLite remains local authority and passport sync
+  (Google Drive Device Code OAuth or S3-compatible storage) is opt-in.
+- Drive inventory/cleanup is an independent safety lane: exact root, recursive
+  manifest, durable backup/restore proof, and exact-ID post-verify are required
+  before any mutation.
 
 ## CD Pipeline
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,15 @@ cosine). Embedding and reranking are forced cloud through the `EMBEDDING_MODELS`
 `RERANK_MODELS` chains (`jina_ai/...`) so the container never downloads the local Qwen3 ONNX
 models, and graph / LLM features run through the `LLM_MODELS` chain (`vertex_express/...`).
 
+### Authority & Sync Boundary
+
+On Cloudflare deployments, **Cloudflare D1 + Vectorize + KV** is the sole production authority:
+- **D1** (`MEMORY_DB_BACKEND=cf-d1`): Authoritative storage for memory rows, metadata, bitemporal valid ranges, and FTS5 search.
+- **Vectorize** (`MCP_VECTORIZE_IDX`): Dense vector index for semantic similarity search.
+- **KV** (`MCP_STORAGE_BACKEND=cf-kv`): Encrypted per-user credential and session store.
+- **Sync boundary** (`SYNC_ENABLED=false`): Production Cloudflare deployments pin legacy Google Drive sync off; Cloudflare serves as the live authority.
+- **Local & self-host bootstrap**: Local stdio (`~/.mnemo-mcp/memories.db`) and self-hosted instances retain optional passport sync (Google Drive Device Code OAuth or S3/R2/B2) for workstation migration.
+
 ## Trust Model
 
 This plugin implements **TC-Local** (machine-bound, single trust principal). The mode/storage/encryption breakdown below is the full classification.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,25 +9,22 @@
 +--------------------+        +---------------------+
 | MCP client         |  MCP   | mnemo-mcp           |
 | (Claude Code,      | <----> | FastMCP server      |
-|  Cursor, Codex,    |        | 15 tools (memory    |
-|  claude.ai web)    |        | + config + help)    |
+| Cursor, Codex,     |        | 15 tools (memory    |
+| claude.ai web)     |        | + config + help)    |
 +--------------------+        +----------+----------+
                                          |
-                                         v
-                                +--------------------+
-                                | SQLite (WAL)       |
-                                |  - memories table  |
-                                |  - memories_fts    |
-                                |  - memories_vec    |
-                                |  - alembic_version |
-                                +--------------------+
+                         +---------------+----------------+
+                         |                                |
+                         v                                v
+                +--------------------+          +------------------------+
+                | Local/self-host    |          | Cloudflare deployment  |
+                | SQLite (WAL)       |          | D1 + Vectorize + KV     |
+                | FTS5 + sqlite-vec  |          | sync disabled           |
+                +--------------------+          +------------------------+
 ```
-
-The server stores everything in a single SQLite file under
-`~/.mnemo-mcp/memories.db` (or `$DB_PATH`). FTS5 + `sqlite-vec` virtual
-tables back the hybrid retrieval pipeline. No external services are
-required for the local-only (ONNX) configuration.
-
+The server supports two distinct storage authorities:
+- **Local / Self-Host Mode**: Stores memories in a single SQLite file under `~/.mnemo-mcp/memories.db` (or `$DB_PATH`). FTS5 + `sqlite-vec` virtual tables back the hybrid retrieval pipeline with optional passport sync (GDrive/S3).
+- **Cloudflare Deployed Mode**: Production authority is Cloudflare D1 (relational rows + FTS5) + Vectorize (dense vector index) + KV (encrypted credentials). `SYNC_ENABLED=false` is enforced in Worker container configuration.
 ## Capture pipeline (`memory(action="capture")`)
 
 ```

--- a/docs/passport.md
+++ b/docs/passport.md
@@ -16,6 +16,22 @@ When you bootstrap a fresh machine you supply your passphrase, point at
 your backend, and `config(action="import_passport")` rehydrates the local
 SQLite store with the full passport content.
 
+## Production authority boundary
+
+Passport sync is a local/self-host migration and backup capability; it is not
+the production source of truth for the hosted Cloudflare deployment. In that
+profile:
+
+- Cloudflare **D1** owns memory rows and FTS5 search.
+- Cloudflare **Vectorize** owns dense vectors.
+- Cloudflare **KV** owns encrypted per-user credentials and session state.
+- `SYNC_ENABLED=false` keeps the legacy database-file Google Drive sync path
+  disabled.
+
+Do not treat a historical Drive `memories.db` or export as a complete inventory
+of current production memories. Any Drive cleanup is a separate exact-root,
+manifest, backup/restore, and exact-ID verification workflow.
+
 ## Backend choice (XOR per deployment mode)
 
 | Backend | Pros | Cons |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # SQLite vector search
     "sqlite-vec",
     # Local ONNX embedding (auto-fallback when no cloud API)
-    "fastretrieval>=1.0.1",
+    "fastretrieval>=1.1.0b1,<2",
     # 1.19.0 ships mcp_core.cli's argument-spec extra subcommand
     # support ((configure, handler) tuples) this repo's cli.py auth
     # subcommand consumes. 1.20.0b2 fixes build_cli's `config`/`doctor`

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -109,6 +109,36 @@ def _configure_cohere_cf_gateway() -> None:
     )
 
 
+def _configure_cohere_direct() -> None:
+    """Configure direct Cohere API route using a skret-provided alias."""
+    token = (
+        os.environ.get("COHERE_API_KEY_DIRECT") or os.environ.get("COHERE_API_KEY", "")
+    ).strip()
+    if not token:
+        raise SystemExit("COHERE_API_KEY_DIRECT (or COHERE_API_KEY) is required.")
+    for env_name in (
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "XAI_API_KEY",
+        "COHERE_API_KEY",
+        "EMBEDDING_MODELS",
+        "EMBEDDING_API_BASE",
+        "RERANK_MODELS",
+        "RERANK_API_BASE",
+        "LLM_MODELS",
+        "LLM_API_BASE",
+    ):
+        os.environ.pop(env_name, None)
+    os.environ.update(
+        {
+            "COHERE_API_KEY": token,
+            "EMBEDDING_MODELS": "cohere/embed-multilingual-v3.0",
+            "RERANK_MODELS": "cohere/rerank-multilingual-v3.0",
+        }
+    )
+
+
 def _password() -> str:
     pw = os.environ.get("RELAY_PW") or os.environ.get("MCP_RELAY_PASSWORD")
     if not pw:
@@ -123,14 +153,14 @@ def _password() -> str:
 def _creds() -> dict[str, str]:
     """Build the per-sub provider and model-routing form payload."""
     creds: dict[str, str] = {}
-    for env_name in (
-        "JINA_AI_API_KEY",
-        "GEMINI_API_KEY",
-        "OPENAI_API_KEY",
-        "COHERE_API_KEY",
-        "XAI_API_KEY",
+    for env_name, alias in (
+        ("JINA_AI_API_KEY", "JINA_AI_API_KEY_DIRECT"),
+        ("GEMINI_API_KEY", "VERTEX_EXPRESS_KEY_DIRECT"),
+        ("OPENAI_API_KEY", None),
+        ("COHERE_API_KEY", "COHERE_API_KEY_DIRECT"),
+        ("XAI_API_KEY", "XAI_API_KEY_DIRECT"),
     ):
-        v = os.environ.get(env_name)
+        v = os.environ.get(env_name) or (os.environ.get(alias) if alias else None)
         if v:
             creds[env_name] = v
     for env_name in (
@@ -614,6 +644,11 @@ def build_parser() -> argparse.ArgumentParser:
             "clears competing provider/model env values without logging secrets."
         ),
     )
+    p.add_argument(
+        "--cohere-direct",
+        action="store_true",
+        help="Use COHERE_API_KEY_DIRECT with LiteLLM direct Cohere route.",
+    )
     mode = p.add_mutually_exclusive_group()
     mode.add_argument(
         "--save-only",
@@ -651,6 +686,9 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.cohere_cf_gateway:
         _configure_cohere_cf_gateway()
+    elif getattr(args, "cohere_direct", False):
+        _configure_cohere_direct()
+
     if args.save_only:
         asyncio.run(run_save_only(args.endpoint))
     elif args.auth_only:

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/mnemo-mcp",
-  "description": "Persistent AI memory with hybrid search (FTS5 + semantic) and cross-machine sync.",
+  "description": "Persistent AI memory with hybrid search and embedded sync. Open, free, unlimited.",
   "repository": {
     "url": "https://github.com/n24q02m/mnemo-mcp.git",
     "source": "github"

--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -22,7 +22,7 @@ Active actions: `status`, `sync`, `set`, `warmup`, `setup_sync`,
 
 ### `status` - Show current configuration
 
-Returns database stats, embedding model info, and sync status.
+Returns database stats, the resolved embedding identity, dimensions, availability, and sync status.
 
 **Parameters:** None
 
@@ -31,7 +31,7 @@ Returns database stats, embedding model info, and sync status.
   `cf-d1:<base-url>` when `MEMORY_DB_BACKEND=cf-d1`
 - `total_memories`: Total memory count
 - `categories`: Memory count by category
-- `embedding`: Model name, dimensions, availability
+- `embedding`: Exact resolved model identity (local model id or cloud candidate), storage dimensions, and availability. FTS-only/unavailable state is represented by a null model.
 - `sync`: Enabled, provider, folder, interval
 
 ### `sync` - Trigger manual sync

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -175,7 +175,7 @@ async def _init_embedding_backend(
                     f"Embedding: local {local_model} "
                     f"(native={native_dims}, stored={embedding_dims})"
                 )
-                ctx["embedding_model"] = "__local__"
+                ctx["embedding_model"] = local_model
                 ctx["embedding_dims"] = embedding_dims
             else:
                 logger.error("Local embedding model not available")

--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -42,9 +42,9 @@ def _resolve_cache_dir() -> Path:
         )
         return Path(old)
 
-    from fastretrieval.common.utils import define_cache_dir
+    from fastretrieval import define_cache_dir
 
-    # Keep cache recovery aligned with fastretrieval's own default path.
+    # Keep cache recovery aligned with fastretrieval's public API and default path.
     return define_cache_dir()
 
 

--- a/tests/test_cf_full_flow.py
+++ b/tests/test_cf_full_flow.py
@@ -56,6 +56,31 @@ def test_configure_cohere_cf_gateway_uses_existing_gateway_token(monkeypatch):
     assert not os.environ.get("JINA_AI_API_KEY")
 
 
+def test_configure_cohere_direct_uses_direct_alias_and_clears_stale_routes(monkeypatch):
+    for name in (
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "XAI_API_KEY",
+        "COHERE_API_KEY",
+        "EMBEDDING_MODELS",
+        "EMBEDDING_API_BASE",
+        "RERANK_MODELS",
+        "RERANK_API_BASE",
+        "LLM_MODELS",
+        "LLM_API_BASE",
+    ):
+        monkeypatch.setenv(name, "stale")
+    monkeypatch.setenv("COHERE_API_KEY_DIRECT", "direct-token")
+
+    _HARNESS._configure_cohere_direct()
+
+    assert os.environ["COHERE_API_KEY"] == "direct-token"
+    assert os.environ["EMBEDDING_MODELS"] == "cohere/embed-multilingual-v3.0"
+    assert os.environ["RERANK_MODELS"] == "cohere/rerank-multilingual-v3.0"
+    assert not os.environ.get("JINA_AI_API_KEY")
+
+
 def test_assert_rerank_payload_requires_semantic_and_reranked_flags():
     payload = {
         "semantic": True,

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -179,7 +179,7 @@ async def test_lifespan_local_backend_explicit(
     server = MagicMock()
     async with lifespan(server) as ctx:
         await _settle_background_init()
-        assert ctx["embedding_model"] == "__local__"
+        assert ctx["embedding_model"] == "local-model"
         assert ctx["embedding_dims"] == 768  # Default for stored
 
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -518,7 +518,7 @@ class TestInitEmbeddingBackendCandidate:
         ctx: dict = {"embedding_model": None, "embedding_dims": 768}
         await _init_embedding_backend("local", ctx)
 
-        assert ctx == {"embedding_model": "__local__", "embedding_dims": 384}
+        assert ctx == {"embedding_model": "local/m", "embedding_dims": 384}
 
 
 class TestCustomEmbeddingRegistration:
@@ -847,7 +847,7 @@ class TestWarmupInitEmbeddingBackend:
         await _init_embedding_backend("local", ctx)
 
         mock_init.assert_called_once_with("local", "local/m")
-        assert ctx["embedding_model"] == "__local__"
+        assert ctx["embedding_model"] == "local/m"
 
     @patch("mnemo_mcp.server._maybe_register_custom_embed")
     @patch(

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -55,6 +55,29 @@ class TestClearModelCache:
 
         assert result is None
 
+    def test_resolve_cache_dir_uses_fastretrieval_public_api(
+        self, tmp_path, monkeypatch
+    ):
+        import fastretrieval
+
+        from mnemo_mcp import setup_tool
+
+        public_cache = tmp_path / "public"
+        monkeypatch.delenv("FASTRETRIEVAL_CACHE_PATH", raising=False)
+        monkeypatch.delenv("QWEN3_EMBED_CACHE_PATH", raising=False)
+
+        public_define = MagicMock(return_value=public_cache)
+        monkeypatch.setattr(
+            fastretrieval, "define_cache_dir", public_define, raising=False
+        )
+        monkeypatch.setattr(
+            "fastretrieval.common.utils.define_cache_dir",
+            MagicMock(side_effect=AssertionError("private fastretrieval import used")),
+        )
+
+        assert setup_tool._resolve_cache_dir() == public_cache
+        public_define.assert_called_once_with()
+
 
 class TestValidateCloudModels:
     """_validate_cloud_models checks cloud embedding availability."""

--- a/tests/test_setup_tool_coverage.py
+++ b/tests/test_setup_tool_coverage.py
@@ -50,7 +50,7 @@ def test_clear_model_cache_fallback_to_fastretrieval_default(tmp_path):
         model_cache.mkdir(parents=True)
 
         with patch(
-            "fastretrieval.common.utils.define_cache_dir",
+            "fastretrieval.define_cache_dir",
             return_value=default_cache_dir,
         ):
             result = clear_model_cache(model_name)

--- a/uv.lock
+++ b/uv.lock
@@ -535,7 +535,7 @@ server = [
 
 [[package]]
 name = "fastretrieval"
-version = "1.0.1"
+version = "1.1.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -546,9 +546,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/35/2a91b42d6b9784ee620d4c75bd2abadbcbd3cf304dcb0a41f5a3a22ee0ba/fastretrieval-1.0.1.tar.gz", hash = "sha256:a1d766e1c1471347ba830c4a7f280ed7b0ff86fbc48425ac457b7b9d8d0e5783", size = 330230, upload-time = "2026-08-14T16:58:25.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2b/00cccf6ead62dc473fb3eccfccd222ca9f481dc85acacb568f49700d159e/fastretrieval-1.1.0b1.tar.gz", hash = "sha256:f5d0609d8255bb66647b65071c802af7401840ba6fedd0d39f93b477fba9722e", size = 330569, upload-time = "2026-08-22T12:47:25.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/94/28ba6e0d86b4b8bb0f2a687d5669bd3c6adb7c3346d6e80431fb66ba6c2d/fastretrieval-1.0.1-py3-none-any.whl", hash = "sha256:902851b02c6b1ffefc66aa63c7976a2226696d7ea2b43b9ec471029e97e58892", size = 144199, upload-time = "2026-08-14T16:58:24.195Z" },
+    { url = "https://files.pythonhosted.org/packages/51/df/bc661390b5a1f06ec476ee23e0e9e848f865b3e80543fcb74e5bf0a254b5/fastretrieval-1.1.0b1-py3-none-any.whl", hash = "sha256:a741bb849e7324d0e11d07b23237b278e45b294c1770ef9a036a77310ebb6bad", size = 144434, upload-time = "2026-08-22T12:47:24.442Z" },
 ]
 
 [[package]]
@@ -1130,7 +1130,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.69" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "fastmcp", specifier = ">=3.4.7,<4" },
-    { name = "fastretrieval", specifier = ">=1.0.1" },
+    { name = "fastretrieval", specifier = ">=1.1.0b1,<2" },
     { name = "httpx" },
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },


### PR DESCRIPTION
## Summary
- define Cloudflare D1 + Vectorize + KV as the hosted production authority
- keep Google Drive passport sync explicitly local/self-host backup and migration, not a production inventory
- strengthen the deployed protocol harness with config status, exact add/search/delete, and multi-candidate D1/Vectorize semantic-rerank verification
- retain the W1 fastretrieval public cache/model-identity contract in this combined integration branch

## Drive authority evidence
- exact account and folder identity verified; identifiers remain in private campaign evidence
- exact target folder inventory: empty; no cleanup mutation required
- isolated empty-manifest restore: passed

## Verification
- focused Cloudflare harness tests: 9 passed
- Ruff lint/format and ty checks: passed

Stable promotion is intentionally out of scope.