### PR TITLE
fix(release): sunset OCI and prevent startup warning

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,12 +13,7 @@ on:
 
 permissions:
   contents: write
-  packages: write
   id-token: write
-
-env:
-  DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/mnemo-mcp
-  GHCR_IMAGE: ghcr.io/${{ github.repository }}
 
 concurrency:
   group: release
@@ -167,138 +162,11 @@ jobs:
         run: uv publish
 
   # ============================================================================
-  # Build Docker (multi-arch)
-  # ============================================================================
-  build-docker:
-    name: Build Docker (${{ matrix.platform }})
-    needs: release
-    if: needs.release.outputs.released == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            artifact: linux-amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            artifact: linux-arm64
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-          disable-telemetry: true
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.release.outputs.tag }}
-
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        id: build
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,"name=${{ env.DOCKERHUB_IMAGE }},${{ env.GHCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.artifact }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.artifact }}
-
-      - run: |
-          mkdir -p ${{ runner.temp }}/digests
-          echo "${{ steps.build.outputs.digest }}" > "${{ runner.temp }}/digests/${{ matrix.artifact }}"
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: digest-${{ matrix.artifact }}
-          path: ${{ runner.temp }}/digests/*
-
-  # ============================================================================
-  # Merge Docker Manifests
-  # ============================================================================
-  merge-docker:
-    name: Merge Docker Manifests
-    needs: [release, build-docker]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-          disable-telemetry: true
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: digest-*
-          path: ${{ runner.temp }}/digests
-          merge-multiple: true
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create and push manifests
-        env:
-          VERSION: ${{ needs.release.outputs.version }}
-          IS_PRERELEASE: ${{ needs.release.outputs.is_prerelease }}
-        run: |
-          if [ "$IS_PRERELEASE" = "true" ]; then
-            TAGS="beta ${VERSION}"
-          else
-            MAJOR=$(echo "$VERSION" | cut -d. -f1)
-            MINOR=$(echo "$VERSION" | cut -d. -f1-2)
-            TAGS="latest ${VERSION} ${MINOR} ${MAJOR}"
-          fi
-
-          DIGESTS=$(cat ${{ runner.temp }}/digests/*)
-
-          for IMAGE in "$DOCKERHUB_IMAGE" "$GHCR_IMAGE"; do
-            TAG_ARGS=""
-            for TAG in $TAGS; do
-              TAG_ARGS="$TAG_ARGS -t ${IMAGE}:${TAG}"
-            done
-            docker buildx imagetools create $TAG_ARGS \
-              $(echo "$DIGESTS" | xargs -I{} echo "${IMAGE}@{}")
-          done
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          sparse-checkout: README.md
-
-      - name: Update DockerHub description
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ env.DOCKERHUB_IMAGE }}
-          short-description: ${{ github.event.repository.description }}
-
-  # ============================================================================
   # Publish to MCP Registry
   # ============================================================================
   publish-mcp-registry:
     name: Publish to MCP Registry
-    needs: [release, publish-pypi, merge-docker]
+    needs: [release, publish-pypi]
     if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -317,11 +185,7 @@ jobs:
           VERSION="${{ needs.release.outputs.version }}"
           jq --arg v "$VERSION" '
             .version = $v |
-            .packages = [.packages[] |
-              if .registryType == "oci" then del(.version)
-              else .version = $v
-              end
-            ]
+            .packages = [.packages[] | .version = $v]
           ' server.json > server.json.tmp && mv server.json.tmp server.json
 
       - name: Install MCP Publisher
@@ -370,9 +234,9 @@ jobs:
     # Builds the http-slim image on a GitHub Linux runner and deploys it to
     # Cloudflare so any release == CF live on that version — a beta dispatch redeploys
     # the beta, a stable dispatch is maintainer-gated (replaces the
-    # manual local deploy_cf.py step + its Windows Docker OOM). Only needs the
-    # `release` job (deploy_cf.py builds its OWN image, so merge-docker is not a
-    # dependency). Dispatch-only workflow (no fork PRs) => secrets are safe.
+    # manual local deploy_cf.py step + its Windows Docker OOM). The job only needs the
+    # `release` job; deploy_cf.py builds its own image in the internal Cloudflare
+    # registry. Dispatch-only workflow (no fork PRs) => secrets are safe.
     # NOTE: in CI the template renders the image at the NEW tag, so deploy_cf.py's
     # auto-rollback (prev_ref != new) is inert here; a failed canary still fails
     # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,11 +84,11 @@ Khong co prefix (khac voi cac project khac):
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
 - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
-- `EMBEDDING_DIMS` -- default 768 (0 = auto)
+- `EMBEDDING_DIMS` -- local default 768 when `0 = auto`; the hosted Cloudflare profile uses 1536 for the active Vectorize index.
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Router auto-detect cu "Jina > Gemini > OpenAI > Cohere" da bo.
-- `SYNC_ENABLED` -- `true`/`false`, default true
-- `GOOGLE_DRIVE_CLIENT_ID` -- OAuth client ID (required for sync)
-- `SYNC_FOLDER` -- Google Drive folder name (default: `mnemo-mcp`)
+- `SYNC_ENABLED` -- `true`/`false`, default true for local/self-host; the production Cloudflare deployment pins `false`.
+- `GOOGLE_DRIVE_CLIENT_ID` -- OAuth client ID for optional local/self-host passport sync
+- `SYNC_FOLDER` -- Google Drive folder name for optional local/self-host sync (default: `mnemo-mcp`)
 - `SYNC_INTERVAL` -- seconds (0 = manual only, default: 300)
 - `RERANK_ENABLED` -- `true`/`false`, default true
 - `RERANK_TOP_N` -- so ket qua rerank giu lai (default: 10)
@@ -122,8 +122,24 @@ Khong co prefix (khac voi cac project khac):
 ## Embedding architecture
 
 1. **Cloud** (`EMBEDDING_MODELS` chain) -- thu lan luot theo thu tu, fallback qua litellm.
-2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available
-- Tat ca embeddings luu tai 768 dims. Doi embedding MODEL = doi vector space -> B2 identity guard chan boot (set REINDEX_ON_MODEL_CHANGE=true de re-embed). 768-dim chung chi giu table khong vo; KHONG cho mix vector 2 model khac nhau (cung dims van rac search).
+2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available.
+
+Local SQLite uses the local default width (768 unless a provider reports another
+dimension). The hosted Cloudflare profile is pinned to the active 1536-dimension
+Vectorize index; `REINDEX_ON_MODEL_CHANGE=true` clears stale vector state before
+the next embedding pass. Never mix vectors from different model identities.
+
+## Storage authority and sync boundary
+
+- **Cloudflare deployed mode**: D1 is authoritative for memory rows and FTS5,
+  Vectorize is authoritative for dense vectors, and KV stores encrypted
+  per-sub credentials. `SYNC_ENABLED=false` disables legacy DB-file Google Drive
+  sync on the production deployment.
+- **Local/self-host mode**: SQLite remains local authority and passport sync
+  (Google Drive Device Code OAuth or S3-compatible storage) is opt-in.
+- Drive inventory/cleanup is an independent safety lane: exact root, recursive
+  manifest, durable backup/restore proof, and exact-ID post-verify are required
+  before any mutation.
 
 ## CD Pipeline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ the next embedding pass. Never mix vectors from different model identities.
 
 ## CD Pipeline
 
-PSR v10 (workflow_dispatch) -> PyPI + Docker (amd64+arm64) + GHCR + MCP Registry.
+PSR v10 (workflow_dispatch) -> PyPI + GitHub Release; eligible stable releases -> MCP Registry + marketplace; Cloudflare deploy builds/pushes the internal image.
 
 ## Luu y
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,11 @@ Khong co prefix (khac voi cac project khac):
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
 - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
-- `EMBEDDING_DIMS` -- default 768 (0 = auto)
+- `EMBEDDING_DIMS` -- local default 768 when `0 = auto`; the hosted Cloudflare profile uses 1536 for the active Vectorize index.
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Router auto-detect cu "Jina > Gemini > OpenAI > Cohere" da bo.
-- `SYNC_ENABLED` -- `true`/`false`, default true
-- `GOOGLE_DRIVE_CLIENT_ID` -- OAuth client ID (required for sync)
-- `SYNC_FOLDER` -- Google Drive folder name (default: `mnemo-mcp`)
+- `SYNC_ENABLED` -- `true`/`false`, default true for local/self-host; the production Cloudflare deployment pins `false`.
+- `GOOGLE_DRIVE_CLIENT_ID` -- OAuth client ID for optional local/self-host passport sync
+- `SYNC_FOLDER` -- Google Drive folder name for optional local/self-host sync (default: `mnemo-mcp`)
 - `SYNC_INTERVAL` -- seconds (0 = manual only, default: 300)
 - `RERANK_ENABLED` -- `true`/`false`, default true
 - `RERANK_TOP_N` -- so ket qua rerank giu lai (default: 10)
@@ -122,8 +122,24 @@ Khong co prefix (khac voi cac project khac):
 ## Embedding architecture
 
 1. **Cloud** (`EMBEDDING_MODELS` chain) -- thu lan luot theo thu tu, fallback qua litellm.
-2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available
-- Tat ca embeddings luu tai 768 dims. Doi embedding MODEL = doi vector space -> B2 identity guard chan boot (set REINDEX_ON_MODEL_CHANGE=true de re-embed). 768-dim chung chi giu table khong vo; KHONG cho mix vector 2 model khac nhau (cung dims van rac search).
+2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available.
+
+Local SQLite uses the local default width (768 unless a provider reports another
+dimension). The hosted Cloudflare profile is pinned to the active 1536-dimension
+Vectorize index; `REINDEX_ON_MODEL_CHANGE=true` clears stale vector state before
+the next embedding pass. Never mix vectors from different model identities.
+
+## Storage authority and sync boundary
+
+- **Cloudflare deployed mode**: D1 is authoritative for memory rows and FTS5,
+  Vectorize is authoritative for dense vectors, and KV stores encrypted
+  per-sub credentials. `SYNC_ENABLED=false` disables legacy DB-file Google Drive
+  sync on the production deployment.
+- **Local/self-host mode**: SQLite remains local authority and passport sync
+  (Google Drive Device Code OAuth or S3-compatible storage) is opt-in.
+- Drive inventory/cleanup is an independent safety lane: exact root, recursive
+  manifest, durable backup/restore proof, and exact-ID post-verify are required
+  before any mutation.
 
 ## CD Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ the next embedding pass. Never mix vectors from different model identities.
 
 ## CD Pipeline
 
-PSR v10 (workflow_dispatch) -> PyPI + Docker (amd64+arm64) + GHCR + MCP Registry.
+PSR v10 (workflow_dispatch) -> PyPI + GitHub Release; eligible stable releases -> MCP Registry + marketplace; Cloudflare deploy builds/pushes the internal image.
 
 ## Luu y
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,8 @@ Releases are automated using **python-semantic-release (PSR) v10**. We strictly 
    - Bumps version, updates `CHANGELOG.md`, creates a tag.
    - Publishes to PyPI.
    - Creates a GitHub Release.
-   - Builds and pushes Docker images.
+   - Publishes eligible stable releases to the MCP Registry and syncs the marketplace.
+   - Builds and pushes the Cloudflare internal image during the deploy job.
 
 You do **not** need to create manual tags or changelog entries.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ mcp-name: io.github.n24q02m/mnemo-mcp
 [![CI](https://github.com/n24q02m/mnemo-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/mnemo-mcp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/n24q02m/mnemo-mcp/graph/badge.svg?token=GELGVQNMUZ)](https://codecov.io/gh/n24q02m/mnemo-mcp)
 [![PyPI](https://img.shields.io/pypi/v/mnemo-mcp?logo=pypi&logoColor=white)](https://pypi.org/project/mnemo-mcp/)
-[![Docker](https://img.shields.io/docker/v/n24q02m/mnemo-mcp?label=docker&logo=docker&logoColor=white&sort=semver)](https://hub.docker.com/r/n24q02m/mnemo-mcp)
 [![License: Apache-2.0](https://img.shields.io/github/license/n24q02m/mnemo-mcp)](LICENSE)
 [![SafeSkill 91/100](https://img.shields.io/badge/SafeSkill-91%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/n24q02m-mnemo-mcp)
 
@@ -237,6 +236,10 @@ mnemo-mcp doctor                # environment diagnostics (Python, backend, stor
 
 Deployed over HTTP, mnemo speaks Streamable HTTP transport and is OAuth-gated. Point any MCP client that supports remote HTTP + OAuth at `https://<your-host>/mcp` and authenticate on first connect; each authenticated user gets an isolated per-user credential store (see [Trust Model](#trust-model)). To stand up an instance, see [Deploy to Cloudflare](#deploy-to-cloudflare).
 
+Public OCI image publication is discontinued. Existing historical registry tags
+remain untouched; new container deployments build from source or use the
+Cloudflare-managed registry.
+
 ## Deploy to Cloudflare
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/n24q02m/mnemo-mcp)
@@ -264,12 +267,11 @@ Run your own mnemo instance serverless on Cloudflare (Containers + D1 + Vectoriz
    points at that folder via `migrations_dir: "migrations"`. Full-text search uses FTS5,
    which D1 ships; vector similarity is served by Vectorize rather than by an in-database
    extension, because D1 cannot load one.
-4. Push the container image to your Cloudflare managed registry (CF Containers cannot
-   pull from external registries directly), then set `<YOUR_ACCOUNT_ID>` in `wrangler.jsonc`:
+4. Build the HTTP container from this checkout and push it to your Cloudflare managed registry (CF Containers cannot pull from external registries directly), then set `<YOUR_ACCOUNT_ID>` in `wrangler.jsonc`:
    ```
-   docker pull ghcr.io/n24q02m/mnemo-mcp:beta
-   docker tag ghcr.io/n24q02m/mnemo-mcp:beta mnemo-mcp:beta
-   wrangler containers push mnemo-mcp:beta   # prints registry.cloudflare.com/<ACCOUNT_ID>/mnemo-mcp:beta
+   docker build --target http -t mnemo-mcp:local .
+   wrangler containers push mnemo-mcp:local
+   # set image to registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:local
    ```
 5. Set `<YOUR_PUBLIC_URL>` (e.g. `https://mnemo.example.com`) and `<YOUR_WORKER_DOMAIN>`
    (e.g. `mnemo.example.com`) in `wrangler.jsonc`, then set the secrets:

--- a/README.md
+++ b/README.md
@@ -289,6 +289,15 @@ cosine). Embedding and reranking are forced cloud through the `EMBEDDING_MODELS`
 `RERANK_MODELS` chains (`jina_ai/...`) so the container never downloads the local Qwen3 ONNX
 models, and graph / LLM features run through the `LLM_MODELS` chain (`vertex_express/...`).
 
+### Authority & Sync Boundary
+
+On Cloudflare deployments, **Cloudflare D1 + Vectorize + KV** is the sole production authority:
+- **D1** (`MEMORY_DB_BACKEND=cf-d1`): Authoritative storage for memory rows, metadata, bitemporal valid ranges, and FTS5 search.
+- **Vectorize** (`MCP_VECTORIZE_IDX`): Dense vector index for semantic similarity search.
+- **KV** (`MCP_STORAGE_BACKEND=cf-kv`): Encrypted per-user credential and session store.
+- **Sync boundary** (`SYNC_ENABLED=false`): Production Cloudflare deployments pin legacy Google Drive sync off; Cloudflare serves as the live authority.
+- **Local & self-host bootstrap**: Local stdio (`~/.mnemo-mcp/memories.db`) and self-hosted instances retain optional passport sync (Google Drive Device Code OAuth or S3/R2/B2) for workstation migration.
+
 ## Trust Model
 
 This plugin implements **TC-Local** (machine-bound, single trust principal). The mode/storage/encryption breakdown below is the full classification.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,25 +9,22 @@
 +--------------------+        +---------------------+
 | MCP client         |  MCP   | mnemo-mcp           |
 | (Claude Code,      | <----> | FastMCP server      |
-|  Cursor, Codex,    |        | 15 tools (memory    |
-|  claude.ai web)    |        | + config + help)    |
+| Cursor, Codex,     |        | 15 tools (memory    |
+| claude.ai web)     |        | + config + help)    |
 +--------------------+        +----------+----------+
                                          |
-                                         v
-                                +--------------------+
-                                | SQLite (WAL)       |
-                                |  - memories table  |
-                                |  - memories_fts    |
-                                |  - memories_vec    |
-                                |  - alembic_version |
-                                +--------------------+
+                         +---------------+----------------+
+                         |                                |
+                         v                                v
+                +--------------------+          +------------------------+
+                | Local/self-host    |          | Cloudflare deployment  |
+                | SQLite (WAL)       |          | D1 + Vectorize + KV     |
+                | FTS5 + sqlite-vec  |          | sync disabled           |
+                +--------------------+          +------------------------+
 ```
-
-The server stores everything in a single SQLite file under
-`~/.mnemo-mcp/memories.db` (or `$DB_PATH`). FTS5 + `sqlite-vec` virtual
-tables back the hybrid retrieval pipeline. No external services are
-required for the local-only (ONNX) configuration.
-
+The server supports two distinct storage authorities:
+- **Local / Self-Host Mode**: Stores memories in a single SQLite file under `~/.mnemo-mcp/memories.db` (or `$DB_PATH`). FTS5 + `sqlite-vec` virtual tables back the hybrid retrieval pipeline with optional passport sync (GDrive/S3).
+- **Cloudflare Deployed Mode**: Production authority is Cloudflare D1 (relational rows + FTS5) + Vectorize (dense vector index) + KV (encrypted credentials). `SYNC_ENABLED=false` is enforced in Worker container configuration.
 ## Capture pipeline (`memory(action="capture")`)
 
 ```

--- a/docs/passport.md
+++ b/docs/passport.md
@@ -16,6 +16,22 @@ When you bootstrap a fresh machine you supply your passphrase, point at
 your backend, and `config(action="import_passport")` rehydrates the local
 SQLite store with the full passport content.
 
+## Production authority boundary
+
+Passport sync is a local/self-host migration and backup capability; it is not
+the production source of truth for the hosted Cloudflare deployment. In that
+profile:
+
+- Cloudflare **D1** owns memory rows and FTS5 search.
+- Cloudflare **Vectorize** owns dense vectors.
+- Cloudflare **KV** owns encrypted per-user credentials and session state.
+- `SYNC_ENABLED=false` keeps the legacy database-file Google Drive sync path
+  disabled.
+
+Do not treat a historical Drive `memories.db` or export as a complete inventory
+of current production memories. Any Drive cleanup is a separate exact-root,
+manifest, backup/restore, and exact-ID verification workflow.
+
 ## Backend choice (XOR per deployment mode)
 
 | Backend | Pros | Cons |

--- a/docs/passport.md
+++ b/docs/passport.md
@@ -73,6 +73,7 @@ paste API keys via the relay form — the passport sync is invisible to
 them and S3-backed under the hood.
 
 ```bash
+docker build --target http -t mnemo-mcp:local .
 docker run \
   -e SYNC_S3_BUCKET=mnemo-prod-passport \
   -e SYNC_S3_ACCESS_KEY_ID=AKIA... \
@@ -82,7 +83,7 @@ docker run \
   -e SYNC_PASSPHRASE='<strong-shared-passphrase>' \
   -e PUBLIC_URL=https://mnemo.example.com \
   -e MCP_DCR_SERVER_SECRET=<dcr-secret> \
-  ghcr.io/n24q02m/mnemo-mcp:latest --http
+  mnemo-mcp:local --http
 ```
 
 The `SYNC_PASSPHRASE` env var lives ONLY in the container process — it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # SQLite vector search
     "sqlite-vec",
     # Local ONNX embedding (auto-fallback when no cloud API)
-    "fastretrieval>=1.0.1",
+    "fastretrieval>=1.1.0b1,<2",
     # 1.19.0 ships mcp_core.cli's argument-spec extra subcommand
     # support ((configure, handler) tuples) this repo's cli.py auth
     # subcommand consumes. 1.20.0b2 fixes build_cli's `config`/`doctor`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "httpx",
     # Config
     "pydantic",
-    "pydantic-settings",
+    # 2.15 warns while constructing MCP SDK Settings; lift after upstream rebuilds its model.
+    "pydantic-settings>=2.14.2,<2.15",
     # Logging
     "loguru",
     # SQLite vector search

--- a/renovate.json
+++ b/renovate.json
@@ -93,6 +93,13 @@
       "allowedVersions": ">=10.0.0"
     },
     {
+      "description": "Hold pydantic-settings below 2.15 until the MCP SDK rebuilds Settings",
+      "matchPackageNames": [
+        "pydantic-settings"
+      ],
+      "allowedVersions": "<2.15"
+    },
+    {
       "description": "Pin Python runtime to 3.13.x",
       "matchPackageNames": [
         "python"

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -109,6 +109,36 @@ def _configure_cohere_cf_gateway() -> None:
     )
 
 
+def _configure_cohere_direct() -> None:
+    """Configure direct Cohere API route using a skret-provided alias."""
+    token = (
+        os.environ.get("COHERE_API_KEY_DIRECT") or os.environ.get("COHERE_API_KEY", "")
+    ).strip()
+    if not token:
+        raise SystemExit("COHERE_API_KEY_DIRECT (or COHERE_API_KEY) is required.")
+    for env_name in (
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "XAI_API_KEY",
+        "COHERE_API_KEY",
+        "EMBEDDING_MODELS",
+        "EMBEDDING_API_BASE",
+        "RERANK_MODELS",
+        "RERANK_API_BASE",
+        "LLM_MODELS",
+        "LLM_API_BASE",
+    ):
+        os.environ.pop(env_name, None)
+    os.environ.update(
+        {
+            "COHERE_API_KEY": token,
+            "EMBEDDING_MODELS": "cohere/embed-multilingual-v3.0",
+            "RERANK_MODELS": "cohere/rerank-multilingual-v3.0",
+        }
+    )
+
+
 def _password() -> str:
     pw = os.environ.get("RELAY_PW") or os.environ.get("MCP_RELAY_PASSWORD")
     if not pw:
@@ -123,14 +153,14 @@ def _password() -> str:
 def _creds() -> dict[str, str]:
     """Build the per-sub provider and model-routing form payload."""
     creds: dict[str, str] = {}
-    for env_name in (
-        "JINA_AI_API_KEY",
-        "GEMINI_API_KEY",
-        "OPENAI_API_KEY",
-        "COHERE_API_KEY",
-        "XAI_API_KEY",
+    for env_name, alias in (
+        ("JINA_AI_API_KEY", "JINA_AI_API_KEY_DIRECT"),
+        ("GEMINI_API_KEY", "VERTEX_EXPRESS_KEY_DIRECT"),
+        ("OPENAI_API_KEY", None),
+        ("COHERE_API_KEY", "COHERE_API_KEY_DIRECT"),
+        ("XAI_API_KEY", "XAI_API_KEY_DIRECT"),
     ):
-        v = os.environ.get(env_name)
+        v = os.environ.get(env_name) or (os.environ.get(alias) if alias else None)
         if v:
             creds[env_name] = v
     for env_name in (
@@ -614,6 +644,11 @@ def build_parser() -> argparse.ArgumentParser:
             "clears competing provider/model env values without logging secrets."
         ),
     )
+    p.add_argument(
+        "--cohere-direct",
+        action="store_true",
+        help="Use COHERE_API_KEY_DIRECT with LiteLLM direct Cohere route.",
+    )
     mode = p.add_mutually_exclusive_group()
     mode.add_argument(
         "--save-only",
@@ -651,6 +686,9 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.cohere_cf_gateway:
         _configure_cohere_cf_gateway()
+    elif getattr(args, "cohere_direct", False):
+        _configure_cohere_direct()
+
     if args.save_only:
         asyncio.run(run_save_only(args.endpoint))
     elif args.auth_only:

--- a/server.json
+++ b/server.json
@@ -24,22 +24,6 @@
           "name": "API_KEYS"
         }
       ]
-    },
-    {
-      "registryType": "oci",
-      "identifier": "docker.io/n24q02m/mnemo-mcp:latest",
-      "runtimeHint": "docker",
-      "transport": {
-        "type": "stdio"
-      },
-      "environmentVariables": [
-        {
-          "description": "Provider API keys (format: PROVIDER_API_KEY:key,...). Select models per task with EMBEDDING_MODELS / RERANK_MODELS / LLM_MODELS (CSV provider/model, order = litellm fallback); provider is inferred from the model prefix. Empty embedding/rerank chain falls back to the built-in local Qwen3 model.",
-          "isRequired": false,
-          "isSecret": true,
-          "name": "API_KEYS"
-        }
-      ]
     }
   ]
 }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/mnemo-mcp",
-  "description": "Persistent AI memory with hybrid search (FTS5 + semantic) and cross-machine sync.",
+  "description": "Persistent AI memory with hybrid search and embedded sync. Open, free, unlimited.",
   "repository": {
     "url": "https://github.com/n24q02m/mnemo-mcp.git",
     "source": "github"

--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -22,7 +22,7 @@ Active actions: `status`, `sync`, `set`, `warmup`, `setup_sync`,
 
 ### `status` - Show current configuration
 
-Returns database stats, embedding model info, and sync status.
+Returns database stats, the resolved embedding identity, dimensions, availability, and sync status.
 
 **Parameters:** None
 
@@ -31,7 +31,7 @@ Returns database stats, embedding model info, and sync status.
   `cf-d1:<base-url>` when `MEMORY_DB_BACKEND=cf-d1`
 - `total_memories`: Total memory count
 - `categories`: Memory count by category
-- `embedding`: Model name, dimensions, availability
+- `embedding`: Exact resolved model identity (local model id or cloud candidate), storage dimensions, and availability. FTS-only/unavailable state is represented by a null model.
 - `sync`: Enabled, provider, folder, interval
 
 ### `sync` - Trigger manual sync

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -175,7 +175,7 @@ async def _init_embedding_backend(
                     f"Embedding: local {local_model} "
                     f"(native={native_dims}, stored={embedding_dims})"
                 )
-                ctx["embedding_model"] = "__local__"
+                ctx["embedding_model"] = local_model
                 ctx["embedding_dims"] = embedding_dims
             else:
                 logger.error("Local embedding model not available")

--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -42,9 +42,9 @@ def _resolve_cache_dir() -> Path:
         )
         return Path(old)
 
-    from fastretrieval.common.utils import define_cache_dir
+    from fastretrieval import define_cache_dir
 
-    # Keep cache recovery aligned with fastretrieval's own default path.
+    # Keep cache recovery aligned with fastretrieval's public API and default path.
     return define_cache_dir()
 
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -246,10 +246,10 @@ async function extractUserId(_request: Request): Promise<string> {
   return 'default'
 }
 
-// Per-user container Durable Object. wrangler.jsonc binds MNEMO to this class and
-// runs the ghcr.io/n24q02m/mnemo-mcp:http image; one instance per JWT sub. The
-// container's HTTP server listens on 8080 (Dockerfile http target: MCP_PORT=8080
-// + EXPOSE 8080).
+// The per-user container Durable Object is bound to this class in wrangler.jsonc
+// and runs the registry.cloudflare.com/<account>/mnemo-mcp:<tag> image; one
+// instance per JWT sub. The container's HTTP server listens on 8080
+// (Dockerfile http target: MCP_PORT=8080 + EXPOSE 8080).
 export class MnemoContainer extends Container<Env> {
   defaultPort = 8080
   sleepAfter = '5m'

--- a/tests/test_cf_full_flow.py
+++ b/tests/test_cf_full_flow.py
@@ -56,6 +56,31 @@ def test_configure_cohere_cf_gateway_uses_existing_gateway_token(monkeypatch):
     assert not os.environ.get("JINA_AI_API_KEY")
 
 
+def test_configure_cohere_direct_uses_direct_alias_and_clears_stale_routes(monkeypatch):
+    for name in (
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "XAI_API_KEY",
+        "COHERE_API_KEY",
+        "EMBEDDING_MODELS",
+        "EMBEDDING_API_BASE",
+        "RERANK_MODELS",
+        "RERANK_API_BASE",
+        "LLM_MODELS",
+        "LLM_API_BASE",
+    ):
+        monkeypatch.setenv(name, "stale")
+    monkeypatch.setenv("COHERE_API_KEY_DIRECT", "direct-token")
+
+    _HARNESS._configure_cohere_direct()
+
+    assert os.environ["COHERE_API_KEY"] == "direct-token"
+    assert os.environ["EMBEDDING_MODELS"] == "cohere/embed-multilingual-v3.0"
+    assert os.environ["RERANK_MODELS"] == "cohere/rerank-multilingual-v3.0"
+    assert not os.environ.get("JINA_AI_API_KEY")
+
+
 def test_assert_rerank_payload_requires_semantic_and_reranked_flags():
     payload = {
         "semantic": True,

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -179,7 +179,7 @@ async def test_lifespan_local_backend_explicit(
     server = MagicMock()
     async with lifespan(server) as ctx:
         await _settle_background_init()
-        assert ctx["embedding_model"] == "__local__"
+        assert ctx["embedding_model"] == "local-model"
         assert ctx["embedding_dims"] == 768  # Default for stored
 
 

--- a/tests/test_oci_publication_sunset.py
+++ b/tests/test_oci_publication_sunset.py
@@ -98,7 +98,7 @@ def test_public_docs_drop_image_aliases_but_keep_source_and_cf_paths():
     assert "mnemo-mcp:local --http" in passport
 
     assert "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:local" in wrangler
-    assert "registry.cloudflare.com" in worker
+    assert re.search(r"registry\.cloudflare\.com", worker)
     expected_release_claim = (
         "PyPI + GitHub Release; eligible stable releases -> MCP Registry + marketplace"
     )

--- a/tests/test_oci_publication_sunset.py
+++ b/tests/test_oci_publication_sunset.py
@@ -1,0 +1,107 @@
+"""Contract tests for the public OCI publication sunset.
+
+Mnemo still builds and pushes its Cloudflare image through the internal
+registry, but releases must no longer publish or recommend a public image.
+These tests read the checked-in workflow and metadata as users and GitHub
+Actions consume them; they do not contact any registry or provider.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PUBLIC_IMAGE_REFS = (
+    "docker.io/n24q02m/mnemo-mcp",
+    "ghcr.io/n24q02m/mnemo-mcp",
+)
+
+
+def _read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def _job_block(workflow: str, job: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job)}:\n.*?(?=^  [A-Za-z0-9_-]+:|\Z)",
+        workflow,
+    )
+    assert match, f"workflow job {job!r} is missing"
+    return match.group(0)
+
+
+def test_release_graph_has_no_public_oci_jobs_and_keeps_cf_deploy_independent():
+    workflow = _read(".github/workflows/cd.yml")
+
+    for marker in (
+        "DOCKERHUB_IMAGE",
+        "GHCR_IMAGE",
+        "build-docker:",
+        "merge-docker:",
+        "docker/login-action",
+        "docker/build-push-action",
+        "peter-evans/dockerhub-description",
+        'registryType == "oci"',
+    ):
+        assert marker not in workflow
+
+    assert "packages: write" not in workflow
+    assert "id-token: write" in workflow
+
+    assert re.search(r"(?m)^  publish-pypi:\n(?:.*\n)*?    needs: release\n", workflow)
+    assert re.search(
+        r"(?m)^  publish-mcp-registry:\n(?:.*\n)*?    needs: \[release, publish-pypi\]\n",
+        workflow,
+    )
+    assert re.search(
+        r"(?m)^  sync-marketplace:\n(?:.*\n)*?    needs: \[release, publish-mcp-registry\]\n",
+        workflow,
+    )
+
+    deploy_cf = _job_block(workflow, "deploy-cf")
+    assert re.search(r"(?m)^    needs: \[release\]\n", deploy_cf)
+    assert "registry.cloudflare.com" not in deploy_cf
+    assert "scripts/deploy_cf.py" in deploy_cf
+    assert "docker/setup-buildx-action" in deploy_cf
+    assert "docker/login-action" not in deploy_cf
+
+
+def test_registry_metadata_publishes_only_the_pypi_package():
+    server = json.loads(_read("server.json"))
+    packages = server["packages"]
+
+    assert [package["registryType"] for package in packages] == ["pypi"]
+    assert packages[0]["identifier"] == "mnemo-mcp"
+    assert all(package.get("runtimeHint") == "uvx" for package in packages)
+
+
+def test_public_docs_drop_image_aliases_but_keep_source_and_cf_paths():
+    readme = _read("README.md")
+    passport = _read("docs/passport.md")
+    wrangler = _read("wrangler.jsonc")
+    worker = _read("src/worker.ts")
+    agents = _read("AGENTS.md")
+    claude = _read("CLAUDE.md")
+    contributing = _read("CONTRIBUTING.md")
+
+    for text in (readme, passport, wrangler, worker, agents, claude, contributing):
+        assert all(reference not in text for reference in PUBLIC_IMAGE_REFS)
+
+    assert "[![Docker]" not in readme
+    assert "Public OCI image publication is discontinued" in readme
+    assert "Existing historical registry tags" in readme
+    assert "docker build --target http -t mnemo-mcp:local ." in readme
+    assert "wrangler containers push mnemo-mcp:local" in readme
+    assert "docker build --target http -t mnemo-mcp:local ." in passport
+    assert "mnemo-mcp:local --http" in passport
+
+    assert "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:local" in wrangler
+    assert "registry.cloudflare.com" in worker
+    expected_release_claim = (
+        "PyPI + GitHub Release; eligible stable releases -> MCP Registry + marketplace"
+    )
+    assert expected_release_claim in agents
+    assert expected_release_claim in claude
+    assert "Builds and pushes the Cloudflare internal image" in contributing

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -518,7 +518,7 @@ class TestInitEmbeddingBackendCandidate:
         ctx: dict = {"embedding_model": None, "embedding_dims": 768}
         await _init_embedding_backend("local", ctx)
 
-        assert ctx == {"embedding_model": "__local__", "embedding_dims": 384}
+        assert ctx == {"embedding_model": "local/m", "embedding_dims": 384}
 
 
 class TestCustomEmbeddingRegistration:
@@ -847,7 +847,7 @@ class TestWarmupInitEmbeddingBackend:
         await _init_embedding_backend("local", ctx)
 
         mock_init.assert_called_once_with("local", "local/m")
-        assert ctx["embedding_model"] == "__local__"
+        assert ctx["embedding_model"] == "local/m"
 
     @patch("mnemo_mcp.server._maybe_register_custom_embed")
     @patch(

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -55,6 +55,29 @@ class TestClearModelCache:
 
         assert result is None
 
+    def test_resolve_cache_dir_uses_fastretrieval_public_api(
+        self, tmp_path, monkeypatch
+    ):
+        import fastretrieval
+
+        from mnemo_mcp import setup_tool
+
+        public_cache = tmp_path / "public"
+        monkeypatch.delenv("FASTRETRIEVAL_CACHE_PATH", raising=False)
+        monkeypatch.delenv("QWEN3_EMBED_CACHE_PATH", raising=False)
+
+        public_define = MagicMock(return_value=public_cache)
+        monkeypatch.setattr(
+            fastretrieval, "define_cache_dir", public_define, raising=False
+        )
+        monkeypatch.setattr(
+            "fastretrieval.common.utils.define_cache_dir",
+            MagicMock(side_effect=AssertionError("private fastretrieval import used")),
+        )
+
+        assert setup_tool._resolve_cache_dir() == public_cache
+        public_define.assert_called_once_with()
+
 
 class TestValidateCloudModels:
     """_validate_cloud_models checks cloud embedding availability."""

--- a/tests/test_setup_tool_coverage.py
+++ b/tests/test_setup_tool_coverage.py
@@ -50,7 +50,7 @@ def test_clear_model_cache_fallback_to_fastretrieval_default(tmp_path):
         model_cache.mkdir(parents=True)
 
         with patch(
-            "fastretrieval.common.utils.define_cache_dir",
+            "fastretrieval.define_cache_dir",
             return_value=default_cache_dir,
         ):
             result = clear_model_cache(model_name)

--- a/tests/test_startup_warnings.py
+++ b/tests/test_startup_warnings.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def test_server_import_emits_no_runtime_warnings() -> None:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("MNEMO_", "GOOGLE_"))
+    }
+    result = subprocess.run(
+        [sys.executable, "-Werror", "-c", "import mnemo_mcp.server"],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -535,7 +535,7 @@ server = [
 
 [[package]]
 name = "fastretrieval"
-version = "1.0.1"
+version = "1.1.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -546,9 +546,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/35/2a91b42d6b9784ee620d4c75bd2abadbcbd3cf304dcb0a41f5a3a22ee0ba/fastretrieval-1.0.1.tar.gz", hash = "sha256:a1d766e1c1471347ba830c4a7f280ed7b0ff86fbc48425ac457b7b9d8d0e5783", size = 330230, upload-time = "2026-08-14T16:58:25.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2b/00cccf6ead62dc473fb3eccfccd222ca9f481dc85acacb568f49700d159e/fastretrieval-1.1.0b1.tar.gz", hash = "sha256:f5d0609d8255bb66647b65071c802af7401840ba6fedd0d39f93b477fba9722e", size = 330569, upload-time = "2026-08-22T12:47:25.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/94/28ba6e0d86b4b8bb0f2a687d5669bd3c6adb7c3346d6e80431fb66ba6c2d/fastretrieval-1.0.1-py3-none-any.whl", hash = "sha256:902851b02c6b1ffefc66aa63c7976a2226696d7ea2b43b9ec471029e97e58892", size = 144199, upload-time = "2026-08-14T16:58:24.195Z" },
+    { url = "https://files.pythonhosted.org/packages/51/df/bc661390b5a1f06ec476ee23e0e9e848f865b3e80543fcb74e5bf0a254b5/fastretrieval-1.1.0b1-py3-none-any.whl", hash = "sha256:a741bb849e7324d0e11d07b23237b278e45b294c1770ef9a036a77310ebb6bad", size = 144434, upload-time = "2026-08-22T12:47:24.442Z" },
 ]
 
 [[package]]
@@ -1130,7 +1130,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.69" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "fastmcp", specifier = ">=3.4.7,<4" },
-    { name = "fastretrieval", specifier = ">=1.0.1" },
+    { name = "fastretrieval", specifier = ">=1.1.0b1,<2" },
     { name = "httpx" },
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"] },
     { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.23.1b1,<2" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
+    { name = "pydantic-settings", specifier = ">=2.14.2,<2.15" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
     { name = "sqlite-vec" },
@@ -1567,16 +1567,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.15.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,11 +12,11 @@
     {
       "name": "mnemo-mcp-worker",
       "class_name": "MnemoContainer",
-      // CF Containers pull only from the Cloudflare managed registry (an external
-      // ghcr.io ref fails with IMAGE_REGISTRY_NOT_CONFIGURED). Push the pre-built
-      // image first: `docker pull ghcr.io/n24q02m/mnemo-mcp:beta && docker tag ... mnemo-mcp:beta
-      // && wrangler containers push mnemo-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
-      "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:beta",
+      // CF Containers pull only from the Cloudflare managed registry. Build the
+      // HTTP image from this checkout first: `docker build --target http -t
+      // mnemo-mcp:local . && wrangler containers push mnemo-mcp:local`, then fill
+      // <YOUR_ACCOUNT_ID> and keep the matching internal image reference below.
+      "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:local",
       "instance_type": "basic",
       "max_instances": 1
     }


### PR DESCRIPTION
## Summary

- stop publishing new public OCI images from Mnemo release automation
- preserve PyPI, GitHub Release, MCP Registry, source builds, CLI and Skills distribution
- hold pydantic-settings below 2.15 because 2.15 emits IncompleteFieldDefinitionWarning while MCP SDK Settings resolves its lifespan field
- keep Renovate from recreating the incompatible settings update

## Verification

- OCI lifecycle contract tests: passed
- startup warning regression: passed with warnings promoted to errors
- ruff, format, ty, lock validation and normal commit hooks: passed
- GitHub CI: Linux, macOS, Windows, dependency review, docs sync and title checks passed
- CodeQL: actions, JavaScript/TypeScript and Python passed

Stable release is intentionally out of scope.