### PR TITLE
feat: add fuzzy matching for invalid source in import_passport action

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,6 @@ reviewable surface here is -- the `error`, `suggestion` and `note` strings in
 `src/mnemo_mcp/server.py` and the tool docs under `src/mnemo_mcp/docs/` -- and
 that a decision to change nothing belongs in this file as an entry. Read this
 file before opening anything against this repository.
+## 2026-08-25 - [DX] Fuzzy matching for missing backends on config passport import
+**Learning:** Returning a raw unhandled exception or an empty error when an invalid backend source is provided leaves the developer guessing what went wrong, which degrades Developer Experience (DX). In backend MCP servers, applying a "Did you mean 'X'?" or listing valid values helps.
+**Action:** When `_handle_config_import_passport` encounters an unknown backend via `get_backend`, use `difflib.get_close_matches` and `mnemo_mcp.sync.list_backends()` to give a clear `suggestion` inside the error response.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2530,10 +2530,24 @@ async def _handle_config_import_passport(
         backend = get_backend(target)
         bundle = await backend.pull(sequence=None)
     except KeyError as e:
-        return {
+        from mnemo_mcp.sync import list_backends
+
+        valid_backends = list_backends()
+        closest = (
+            difflib.get_close_matches(str(target), valid_backends, n=1)
+            if target is not None
+            else []
+        )
+        resp = {
             "error": str(e),
-            "suggestion": "Ensure the specified backend is properly configured.",
         }
+        if closest:
+            resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+        else:
+            resp["suggestion"] = (
+                f"Ensure the specified backend is properly configured. Available backends are: {', '.join(valid_backends)}."
+            )
+        return resp
     except Exception:
         logger.exception("import_passport: backend pull failed")
         return {

--- a/tests/test_passport_actions.py
+++ b/tests/test_passport_actions.py
@@ -182,6 +182,46 @@ async def test_export_passport_requires_passphrase(
 # ---------------------------------------------------------------------------
 
 
+async def test_import_passport_invalid_source_fuzzy_suggestion(
+    isolated_db: MemoryDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SYNC_PASSPHRASE", "test-pass")
+    from mnemo_mcp import sync as sync_pkg
+    from mnemo_mcp.sync.base import SyncBackend
+
+    class DummyBackend(SyncBackend):
+        name = "dummy"
+
+        async def push(self, bundle: bytes, sequence: int) -> None:
+            pass
+
+        async def pull(self, sequence=None) -> bytes | None:
+            return b""
+
+        async def last_remote_sequence(self) -> int:
+            return 0
+
+        async def health_check(self) -> bool:
+            return True
+
+    # We must register some backends so `list_backends()` returns them
+    sync_pkg.register("s3", DummyBackend())
+
+    try:
+        ctx = _make_ctx(isolated_db)
+        raw = await _handle_config_import_passport(ctx, source="s4")
+
+        assert "error" in raw
+        assert "Unknown sync backend" in raw["error"]
+        assert "suggestion" in raw
+        assert (
+            "Did you mean 's3'?" in raw["suggestion"]
+            or "Available backends are: " in raw["suggestion"]
+        )
+    finally:
+        sync_pkg.reset_registry()
+
+
 async def test_import_passport_requires_passphrase(
     isolated_db: MemoryDB,
 ) -> None:


### PR DESCRIPTION
This pull request implements a micro-UX improvement for the `mnemo-mcp` backend configuration.

Previously, if a user or LLM provided an invalid `source` (backend) to the `config(action="import_passport", from="s4")` command, the server raised a generic `KeyError` wrapped into the error response without any actionable feedback.

Now, we use `difflib.get_close_matches` to compare the invalid input against the known registered backends (from `mnemo_mcp.sync.list_backends()`). 
* If a typo is found (e.g., `s4` instead of `s3`), it suggests "Did you mean 's3'?".
* If no match is found, it lists all currently available backends.

This makes debugging sync issues much smoother and saves round trips to the documentation. Tests have been added to `tests/test_passport_actions.py` to ensure correct error parsing and suggestions.

---
*PR created automatically by Jules for task [9971259724791691363](https://jules.google.com/task/9971259724791691363) started by @n24q02m*