### PR TITLE
fix: prevent information disclosure in config API responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@ recur. Its ledger entry was dated `2025-02-14`, more than a year off, and it was
 written at `##` where the entries around it were `###`, which filed a shipped fix
 under "Rejected". Date an entry from the commit that carries it, and check which
 section the heading level puts it in.
+
+## 2026-08-26 - Prevent Information Disclosure in Backend Config Error Responses
+**Vulnerability:** Raw exception strings (`str(e)`) mapping to missing configuration keys were returned directly in the JSON response of `_handle_config_sync_now` and `_handle_config_import_passport` when catching `KeyError`.
+**Learning:** Returning dictionary key error messages to the client exposes the internal name and configuration structure of backend integrations, continuing a pattern of information disclosure previously addressed for general exceptions. The principle of not exposing internal workings applies equally to configuration validation errors as it does to runtime exceptions.
+**Prevention:** Replace dynamically generated `str(e)` bindings in error handlers with generic static messages like `"backend configuration incomplete"`, logging the detailed exception context serverside to retain diagnostic information without leaking structure.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2469,9 +2469,10 @@ async def _handle_config_sync_now(
 
         result = await sync_now(db, target, passphrase)
         return {"backend": target, **result}
-    except KeyError as e:
+    except KeyError:
+        logger.exception("sync_now failed")
         return {
-            "error": str(e),
+            "error": "backend configuration incomplete",
             "suggestion": "Check if backend configuration is complete.",
         }
     except Exception:
@@ -2530,9 +2531,10 @@ async def _handle_config_import_passport(
 
         backend = get_backend(target)
         bundle = await backend.pull(sequence=None)
-    except KeyError as e:
+    except KeyError:
+        logger.exception("import_passport failed")
         return {
-            "error": str(e),
+            "error": "backend configuration incomplete",
             "suggestion": "Ensure the specified backend is properly configured.",
         }
     except Exception:

--- a/tests/test_passport_actions.py
+++ b/tests/test_passport_actions.py
@@ -131,7 +131,18 @@ async def test_sync_now_unknown_backend(
     raw = await _handle_config_sync_now(ctx, backend="nonexistent")
     payload = raw
     assert "error" in payload
-    assert "nonexistent" in payload["error"]
+    assert "backend configuration incomplete" in payload["error"]
+
+
+async def test_import_passport_unknown_backend(
+    isolated_db: MemoryDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SYNC_PASSPHRASE", "test-pass")
+    ctx = _make_ctx(isolated_db)
+    raw = await _handle_config_import_passport(ctx, source="nonexistent")
+    payload = raw
+    assert "error" in payload
+    assert "backend configuration incomplete" in payload["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### 🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Config Sync/Import Responses

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Raw `KeyError` exception strings were being exposed directly to clients when invalid backend names were provided. This could leak the internal configuration structure. 
**🎯 Impact:** Exposed internal application state, helping a malicious user probe configuration constraints.
**🔧 Fix:** Replaced `str(e)` bindings in error handlers with a static, generic error message (`"backend configuration incomplete"`) while securely utilizing `logger.exception()` on the server side to maintain trace logs for debugging.
**✅ Verification:** The updated response has been validated by running the existing and new integration tests (`test_sync_now_unknown_backend` and `test_import_passport_unknown_backend`), and all repository tests and lints pass successfully.

---
*PR created automatically by Jules for task [11511777420084213367](https://jules.google.com/task/11511777420084213367) started by @n24q02m*