### PR TITLE
feat: add suggestion to missing embedding backend error

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2063,6 +2063,7 @@ async def _handle_config_backfill(
         return {
             "status": "unavailable",
             "error": "No embedding backend is configured for the current subject.",
+            "suggestion": "Check embedding provider configuration or provide API keys via environment variables.",
             "scanned": 0,
             "embedded": 0,
             "skipped": 0,

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -247,6 +247,7 @@ class TestConfigSync:
         assert result == {
             "status": "unavailable",
             "error": "No embedding backend is configured for the current subject.",
+            "suggestion": "Check embedding provider configuration or provide API keys via environment variables.",
             "scanned": 0,
             "embedded": 0,
             "skipped": 0,


### PR DESCRIPTION
Adds a `suggestion` key to the error response in `config` when `action="backfill_embeddings"` fails because no embedding backend is configured. This matches Palette's mandate to provide consistent error suggestions in backend MCP servers. Test expectations are also updated to expect this suggestion.

---
*PR created automatically by Jules for task [16568629594016244067](https://jules.google.com/task/16568629594016244067) started by @n24q02m*