### PR TITLE
feat: improve error suggestions with fuzzy matching in backend config tools

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,6 @@ reviewable surface here is -- the `error`, `suggestion` and `note` strings in
 `src/mnemo_mcp/server.py` and the tool docs under `src/mnemo_mcp/docs/` -- and
 that a decision to change nothing belongs in this file as an entry. Read this
 file before opening anything against this repository.
+## 2026-08-27 - Backend error fallback suggestions for missing targets
+**Learning:** Returning a raw "KeyError: 'backend'" message from `import_passport` and `sync_now` when an invalid backend target is supplied leaves developers without actionable feedback.
+**Action:** Use `difflib.get_close_matches` combined with a fallback list of available backends from `list_backends` when handling invalid target backends to catch typos and provide actionable error `suggestion`s.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2470,9 +2470,20 @@ async def _handle_config_sync_now(
         result = await sync_now(db, target, passphrase)
         return {"backend": target, **result}
     except KeyError as e:
+        from mnemo_mcp.sync import list_backends
+
+        closest = (
+            difflib.get_close_matches(str(target), list_backends(), n=1)
+            if target is not None
+            else []
+        )
+        if closest:
+            suggestion = f"Did you mean '{closest[0]}'?"
+        else:
+            suggestion = f"Check if backend configuration is complete. Available backends: {', '.join(list_backends())}."
         return {
             "error": str(e),
-            "suggestion": "Check if backend configuration is complete.",
+            "suggestion": suggestion,
         }
     except Exception:
         logger.exception("sync_now failed")
@@ -2531,9 +2542,20 @@ async def _handle_config_import_passport(
         backend = get_backend(target)
         bundle = await backend.pull(sequence=None)
     except KeyError as e:
+        from mnemo_mcp.sync import list_backends
+
+        closest = (
+            difflib.get_close_matches(str(target), list_backends(), n=1)
+            if target is not None
+            else []
+        )
+        if closest:
+            suggestion = f"Did you mean '{closest[0]}'?"
+        else:
+            suggestion = f"Ensure the specified backend is properly configured. Available backends: {', '.join(list_backends())}."
         return {
             "error": str(e),
-            "suggestion": "Ensure the specified backend is properly configured.",
+            "suggestion": suggestion,
         }
     except Exception:
         logger.exception("import_passport: backend pull failed")


### PR DESCRIPTION
This PR improves the error suggestions returned by `config(action="sync_now")` and `config(action="import_passport")` when an invalid backend target is supplied. Previously, passing an unregistered backend would result in a raw `KeyError` string. This change intercepts the `KeyError` and provides actionable feedback using `difflib.get_close_matches` against the list of available backends.

---
*PR created automatically by Jules for task [6794019984993095321](https://jules.google.com/task/6794019984993095321) started by @n24q02m*