### PR TITLE
feat: add suggestion to backfill embedding error

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2063,6 +2063,7 @@ async def _handle_config_backfill(
         return {
             "status": "unavailable",
             "error": "No embedding backend is configured for the current subject.",
+            "suggestion": "Verify embedding configuration or run the setup flow.",
             "scanned": 0,
             "embedded": 0,
             "skipped": 0,

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -247,6 +247,7 @@ class TestConfigSync:
         assert result == {
             "status": "unavailable",
             "error": "No embedding backend is configured for the current subject.",
+            "suggestion": "Verify embedding configuration or run the setup flow.",
             "scanned": 0,
             "embedded": 0,
             "skipped": 0,


### PR DESCRIPTION
This PR adds an actionable `"suggestion"` to the error response returned by `_handle_config_backfill` in `src/mnemo_mcp/server.py` when an embedding backend is unconfigured. 

This directly addresses the UX/DX requirement for the Palette agent to "Improve error message clarity with actionable steps."

It also updates the corresponding test in `tests/test_server_coverage.py` to assert the presence of this new key. All existing tests and linting pass.

---
*PR created automatically by Jules for task [16543530987868775542](https://jules.google.com/task/16543530987868775542) started by @n24q02m*