### PR TITLE
fix: 🛡️ Sentinel: [MEDIUM] Fix information disclosure in backend configuration errors

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@ recur. Its ledger entry was dated `2025-02-14`, more than a year off, and it was
 written at `##` where the entries around it were `###`, which filed a shipped fix
 under "Rejected". Date an entry from the commit that carries it, and check which
 section the heading level puts it in.
+
+## 2026-08-29 - Prevent Information Disclosure in Backend Configuration Errors
+**Vulnerability:** Raw exception strings from `KeyError` (e.g., `str(e)`) were exposed in the JSON response payload of `sync_now` and `import_passport` tool handlers when an unknown or misconfigured backend was requested.
+**Learning:** Returning exception details like `str(e)` from `KeyError` directly to the client can leak sensitive internal configuration keys or backend structure details. Exception strings should be masked with generic error messages in API responses.
+**Prevention:** Catch `KeyError` without an `as e` binding, log the exception securely on the server using `logger.exception()`, and return a generic error message (e.g., `"backend configuration incomplete"`) to the client.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2469,9 +2469,10 @@ async def _handle_config_sync_now(
 
         result = await sync_now(db, target, passphrase)
         return {"backend": target, **result}
-    except KeyError as e:
+    except KeyError:
+        logger.exception("sync_now failed: backend not found")
         return {
-            "error": str(e),
+            "error": "backend configuration incomplete",
             "suggestion": "Check if backend configuration is complete.",
         }
     except Exception:
@@ -2530,9 +2531,10 @@ async def _handle_config_import_passport(
 
         backend = get_backend(target)
         bundle = await backend.pull(sequence=None)
-    except KeyError as e:
+    except KeyError:
+        logger.exception("import_passport failed: backend not found")
         return {
-            "error": str(e),
+            "error": "backend configuration incomplete",
             "suggestion": "Ensure the specified backend is properly configured.",
         }
     except Exception:

--- a/tests/test_passport_actions.py
+++ b/tests/test_passport_actions.py
@@ -131,7 +131,7 @@ async def test_sync_now_unknown_backend(
     raw = await _handle_config_sync_now(ctx, backend="nonexistent")
     payload = raw
     assert "error" in payload
-    assert "nonexistent" in payload["error"]
+    assert "backend configuration incomplete" in payload["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🛡️ **Sentinel: [MEDIUM] Fix information disclosure in backend configuration errors**

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Uncaught `KeyError` string conversions (`str(e)`) were directly exposed to users via the JSON response payloads of the `sync_now` and `import_passport` configuration tool handlers.
🎯 **Impact:** If exploited or provoked, these endpoints could potentially leak sensitive internal configuration names, backend structures, or dict keys directly to a client.
🔧 **Fix:** Replaced `except KeyError as e:` with `except KeyError:`, logged the error securely server-side using `logger.exception()`, and returning a statically defined `"backend configuration incomplete"` generic error string. Updated the corresponding test assertions in `tests/test_passport_actions.py` to match.
✅ **Verification:** Ran `uv run pytest tests/test_passport_actions.py` and the full suite. All tests passing. Added journal learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3741095638784314720](https://jules.google.com/task/3741095638784314720) started by @n24q02m*