### PR TITLE
fix: remove private fastretrieval test dependencies

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -833,7 +833,6 @@ class TestMaybeRegisterCustomEmbed:
 
     def test_custom_id_registers_with_dim_and_pooling(self):
         import fastretrieval
-        from fastretrieval.common.model_description import PoolingType
 
         with patch.object(fastretrieval.TextEmbedding, "add_custom_model") as mock_add:
             with patch("mnemo_mcp.server.settings") as mock_settings:
@@ -849,7 +848,8 @@ class TestMaybeRegisterCustomEmbed:
             description = mock_add.call_args.args[0]
             assert description.model == "Org/custom-embed"
             assert description.dim == 1024
-            assert mock_add.call_args.kwargs["pooling"] == PoolingType.CLS
+            pooling = mock_add.call_args.kwargs["pooling"]
+            assert getattr(pooling, "name", pooling) == "CLS"
             assert mock_add.call_args.kwargs["normalization"] is True
 
     def test_reregistration_is_graceful(self):

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -75,10 +75,6 @@ class TestClearModelCache:
         monkeypatch.setattr(
             fastretrieval, "define_cache_dir", public_define, raising=False
         )
-        monkeypatch.setattr(
-            "fastretrieval.common.utils.define_cache_dir",
-            MagicMock(side_effect=AssertionError("private fastretrieval import used")),
-        )
 
         assert setup_tool._resolve_cache_dir() == public_cache
         public_define.assert_called_once_with()


### PR DESCRIPTION
## Problem
The production consumer already uses Fastretrieval's public facade, but two tests still depended on `fastretrieval.common.*` implementation paths.

## Change
- patch the public `fastretrieval.define_cache_dir` boundary only
- assert pooling behavior from the public registration call result instead of importing the private enum
- no production, manifest, lock, or documentation changes

## Verification
- `uv run pytest tests/test_setup_tool.py tests/test_server.py -q` — 100 passed
- `uv run pytest tests -k "embedding or retrieval or setup or model" -q` — 316 passed
- `uv run ruff check tests/test_setup_tool.py tests/test_server.py` — passed
- `uv lock --check` — passed
- `uv run pre-commit run --files tests/test_setup_tool.py tests/test_server.py` — all applicable hooks passed
- source/manifest/lock and tests contain no `fastretrieval.common.*` dependency

Foundation dependency realignment Task 3.