### PR TITLE
feat: expose reranker selection metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -18,7 +18,7 @@
       },
       "environmentVariables": [
         {
-          "description": "Provider API keys (format: PROVIDER_API_KEY:key,...). Select models per task with EMBEDDING_MODELS / RERANK_MODELS / LLM_MODELS (CSV provider/model, order = litellm fallback); provider is inferred from the model prefix. Empty embedding/rerank chain falls back to the built-in local Qwen3 model.",
+          "description": "Provider API keys (format: PROVIDER_API_KEY:key,...). Select models per task with EMBEDDING_MODELS / RERANK_MODELS / LLM_MODELS (CSV provider/model, order = litellm fallback); provider is inferred from the model prefix. Empty embedding/rerank chains select Fastretrieval local ONNX/GGUF models; configured cloud chains never silently fall back to local.",
           "isRequired": false,
           "isSecret": true,
           "name": "API_KEYS"

--- a/src/mnemo_mcp/docs/memory.md
+++ b/src/mnemo_mcp/docs/memory.md
@@ -88,6 +88,8 @@ Hybrid search combining full-text and semantic similarity.
 - Semantic vector search (when embedding model is configured)
 - Results scored by: text relevance + semantic similarity + recency + access frequency
 - Access count is incremented for returned results
+- Each response reports `semantic`, `reranked`, and a `reranker` object with
+  the selected `backend`, public model identity, and fallback outcome.
 
 **Example:**
 ```json
@@ -213,7 +215,9 @@ Memories older than `ARCHIVE_AFTER_DAYS` (90) with importance below
 
 ### Reranking
 Search results are reranked using a cross-encoder model for improved precision.
-Supports Jina AI and Cohere cloud rerankers, with local Qwen3 as fallback.
+Configured chains use Jina AI or Cohere. An empty chain selects the local
+Fastretrieval Qwen3 model; a configured cloud chain never silently falls back
+to local execution.
 
 ## Proactive Memory Guidelines
 

--- a/src/mnemo_mcp/reranker.py
+++ b/src/mnemo_mcp/reranker.py
@@ -9,6 +9,7 @@ Pipeline: retrieve top-N*3 -> rerank -> return top-N.
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 from loguru import logger
@@ -39,6 +40,9 @@ def _strip_provider(model: str) -> str:
 class RerankerBackend(Protocol):
     """Protocol for reranker backends."""
 
+    backend_name: str
+    model_name: str
+
     def rerank(
         self, query: str, documents: list[str], top_n: int = 10
     ) -> list[tuple[int, float]]:
@@ -51,6 +55,29 @@ class RerankerBackend(Protocol):
     def check_available(self) -> bool:
         """Check if the reranker backend is available."""
         ...
+
+
+@dataclass(frozen=True, slots=True)
+class RerankOutcome:
+    """Per-call rerank result and the backend that produced it."""
+
+    results: list[tuple[int, float]]
+    backend_name: str | None
+    model_name: str | None
+
+
+def describe_reranker(
+    backend: RerankerBackend | None,
+) -> tuple[str | None, str | None]:
+    """Return public backend/model identity without provider credentials."""
+    if backend is None:
+        return None, None
+    backend_name = getattr(backend, "backend_name", None)
+    model_name = getattr(backend, "model_name", None)
+    return (
+        backend_name if isinstance(backend_name, str) else None,
+        model_name if isinstance(model_name, str) else None,
+    )
 
 
 class CloudReranker:
@@ -70,6 +97,8 @@ class CloudReranker:
         self.api_base = api_base
         self.api_key = api_key
         self._provider = _detect_rerank_provider(self.model)
+        self.backend_name = "cloud"
+        self.model_name = self.model
 
     def _litellm_model(self) -> str:
         """Map mnemo's model naming to a litellm ``provider/model`` string."""
@@ -157,6 +186,8 @@ class Qwen3Reranker:
 
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name or self.DEFAULT_MODEL
+        self.backend_name = "local"
+        self.model_name = self._model_name
         self._model = None
 
     def _get_model(self):
@@ -214,6 +245,12 @@ def get_reranker() -> RerankerBackend | None:
     return _backend
 
 
+def clear_reranker() -> None:
+    """Clear the cached reranker backend."""
+    global _backend
+    _backend = None
+
+
 def init_reranker(
     backend_type: str,
     model: str | None = None,
@@ -257,11 +294,29 @@ class FallbackChainReranker:
             raise ValueError("FallbackChainReranker requires at least one backend")
         self._backends = backends
 
+    @property
+    def backend_name(self) -> str:
+        return "fallback-chain"
+
+    @property
+    def model_name(self) -> str:
+        return ",".join(
+            model_name
+            for backend in self._backends
+            if (model_name := describe_reranker(backend)[1]) is not None
+        )
+
     def rerank(
         self, query: str, documents: list[str], top_n: int = 10
     ) -> list[tuple[int, float]]:
+        return self.rerank_with_identity(query, documents, top_n=top_n).results
+
+    def rerank_with_identity(
+        self, query: str, documents: list[str], top_n: int = 10
+    ) -> RerankOutcome:
+        """Rerank once and return call-local selection metadata."""
         if not documents:
-            return []
+            return RerankOutcome([], None, None)
         for backend in self._backends:
             try:
                 ranked = backend.rerank(query, documents, top_n=top_n)
@@ -272,8 +327,9 @@ class FallbackChainReranker:
                 )
                 continue
             if ranked:
-                return ranked
-        return []
+                backend_name, model_name = describe_reranker(backend)
+                return RerankOutcome(ranked, backend_name, model_name)
+        return RerankOutcome([], None, None)
 
     def check_available(self) -> bool:
         """Available if any backend in the chain reports availability."""
@@ -284,6 +340,20 @@ class FallbackChainReranker:
             except Exception:
                 continue
         return False
+
+
+def rerank_with_identity(
+    backend: RerankerBackend,
+    query: str,
+    documents: list[str],
+    top_n: int = 10,
+) -> RerankOutcome:
+    """Run one backend and preserve call-local selection metadata."""
+    if isinstance(backend, FallbackChainReranker):
+        return backend.rerank_with_identity(query, documents, top_n=top_n)
+    results = backend.rerank(query, documents, top_n=top_n)
+    backend_name, model_name = describe_reranker(backend)
+    return RerankOutcome(results, backend_name, model_name)
 
 
 def build_default_rerank_chain(

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -216,7 +216,9 @@ async def _init_reranker_backend(mode: str) -> None:
     CONFIGURED: cloud-only path -- no silent local fallback.
     """
     from mnemo_mcp.credential_state import CredentialState, get_state
-    from mnemo_mcp.reranker import init_reranker
+    from mnemo_mcp.reranker import clear_reranker, init_reranker
+
+    clear_reranker()
 
     backend_type = settings.resolve_rerank_backend()
     if not backend_type:
@@ -246,8 +248,10 @@ async def _init_reranker_backend(mode: str) -> None:
                 logger.info(f"Reranker: local {local_model}")
             else:
                 logger.error("Local reranker not available")
+                clear_reranker()
         except Exception as e:
             logger.error(f"Local reranker init failed: {e}")
+            clear_reranker()
         return
 
     # CONFIGURED + cloud backend -- no local fallback.
@@ -260,8 +264,10 @@ async def _init_reranker_backend(mode: str) -> None:
                 if available:
                     logger.info(f"Reranker: {model}")
                     return
+                clear_reranker()
             except Exception as e:
                 logger.warning(f"Reranker {model} not available: {e}")
+                clear_reranker()
         logger.error("Cloud reranker not available and local fallback is disabled")
 
 
@@ -841,6 +847,10 @@ async def _handle_search(
     # (top-50 -> top-N) so we ask db.search for ``max(50, limit*5)`` rows
     # when a reranker is active and otherwise stay at the LLM-requested limit.
     reranker = _get_request_reranker(ctx)
+    from mnemo_mcp.reranker import describe_reranker, rerank_with_identity
+
+    reranker_backend, reranker_model = describe_reranker(reranker)
+    reranker_fallback = "not_configured" if reranker is None else "not_needed"
     rerank_pool = max(50, limit * 5) if reranker else None
 
     results = await asyncio.to_thread(
@@ -860,11 +870,17 @@ async def _handle_search(
 
     reranked = False
     if reranker and len(results) > 1:
+        reranker_fallback = "none"
         documents = [r["content"] for r in results]
         try:
-            ranked = await asyncio.to_thread(
-                reranker.rerank, query, documents, top_n=limit
+            outcome = await asyncio.to_thread(
+                rerank_with_identity, reranker, query, documents, limit
             )
+            ranked = outcome.results
+            if outcome.backend_name is not None:
+                reranker_backend = outcome.backend_name
+            if outcome.model_name is not None:
+                reranker_model = outcome.model_name
             if ranked:
                 reranked_results = []
                 for idx, score in ranked:
@@ -874,10 +890,12 @@ async def _handle_search(
                 results = reranked_results
                 reranked = True
             else:
+                reranker_fallback = "original_order_after_empty_result"
                 # No reranker output -> fall back to top-``limit`` of the
                 # hybrid-scored pool so the response still respects ``limit``.
                 results = results[:limit]
         except Exception as e:
+            reranker_fallback = "original_order_after_error"
             logger.debug(f"Reranking failed, using original order: {e}")
             results = results[:limit]
     else:
@@ -905,6 +923,11 @@ async def _handle_search(
         "results": [_format_memory(r) for r in results],
         "semantic": embedding is not None,
         "reranked": reranked,
+        "reranker": {
+            "backend": reranker_backend,
+            "model": reranker_model,
+            "fallback": reranker_fallback,
+        },
     }
 
     if len(results) == 0:

--- a/tests/test_live_protocol.py
+++ b/tests/test_live_protocol.py
@@ -496,6 +496,13 @@ class TestGranularRetrieval:
         assert search_data.get("count", 0) >= 1, search_data
         assert search_data.get("semantic") is True, search_data
         assert search_data.get("reranked") is True, search_data
+        reranker = search_data["reranker"]
+        assert reranker["backend"] == "local", reranker
+        assert reranker["model"] in {
+            "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo",
+            "n24q02m/Qwen3-Reranker-0.6B-GGUF",
+        }
+        assert reranker["fallback"] == "none", reranker
 
         r = await local_mcp_session.call_tool("config", {"action": "status"})
         text = parse(r)

--- a/tests/test_retrieval_polish.py
+++ b/tests/test_retrieval_polish.py
@@ -114,6 +114,26 @@ def test_fallback_chain_returns_first_successful():
     good.rerank.assert_called_once()
 
 
+def test_fallback_chain_identity_is_call_local():
+    first = MagicMock(spec=CloudReranker)
+    first.backend_name = "cloud"
+    first.model_name = "jina_ai/jina-reranker-v3"
+    first.rerank.side_effect = [[(0, 0.9)], []]
+
+    second = MagicMock(spec=CloudReranker)
+    second.backend_name = "cloud"
+    second.model_name = "cohere/rerank-v4.0-pro"
+    second.rerank.return_value = [(0, 0.8)]
+
+    chain = FallbackChainReranker([first, second])
+    first_outcome = chain.rerank_with_identity("q1", ["a"], top_n=1)
+    second_outcome = chain.rerank_with_identity("q2", ["b"], top_n=1)
+
+    assert first_outcome.model_name == "jina_ai/jina-reranker-v3"
+    assert second_outcome.model_name == "cohere/rerank-v4.0-pro"
+    assert first_outcome.model_name == "jina_ai/jina-reranker-v3"
+
+
 def test_fallback_chain_all_fail_returns_empty():
     bad1 = MagicMock(spec=CloudReranker)
     bad1.rerank.side_effect = RuntimeError("first")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -642,11 +642,18 @@ class TestSearchRerankerAndGraph:
         db.add("Python for web")
         db.add("Python for data")
         mock_reranker = MagicMock()
+        mock_reranker.backend_name = "local"
+        mock_reranker.model_name = "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
         mock_reranker.rerank.return_value = [(1, 0.95), (0, 0.85), (2, 0.70)]
         with patch("mnemo_mcp.reranker.get_reranker", return_value=mock_reranker):
             result = await _handle_search(ctx, "Python", None, None, 5)
         assert result["reranked"] is True
         assert result["results"][0]["rerank_score"] == 0.95
+        assert result["reranker"] == {
+            "backend": "local",
+            "model": "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo",
+            "fallback": "none",
+        }
 
     async def test_search_reranker_failure(self, ctx_with_db):
         """Cover line 451: reranker failure falls back to original order."""
@@ -654,10 +661,17 @@ class TestSearchRerankerAndGraph:
         db.add("Python for AI")
         db.add("Python for web")
         mock_reranker = MagicMock()
+        mock_reranker.backend_name = "cloud"
+        mock_reranker.model_name = "cohere/rerank-v4.0-pro"
         mock_reranker.rerank.side_effect = RuntimeError("rerank failed")
         with patch("mnemo_mcp.reranker.get_reranker", return_value=mock_reranker):
             result = await _handle_search(ctx, "Python", None, None, 5)
         assert result["reranked"] is False
+        assert result["reranker"] == {
+            "backend": "cloud",
+            "model": "cohere/rerank-v4.0-pro",
+            "fallback": "original_order_after_error",
+        }
 
     async def test_search_with_graph_boost(self, ctx_with_db):
         """Cover lines 463-468: graph boost marks related memories."""

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.reranker import get_reranker, init_reranker
 from mnemo_mcp.server import (
     _enrich_memory,
     _init_reranker_backend,
@@ -133,9 +134,11 @@ class TestInitRerankerBackend:
 
         local_backend = MagicMock()
         local_backend.check_available.return_value = False
+        init_reranker("local", "stale/model")
 
         with patch("mnemo_mcp.reranker.init_reranker", return_value=local_backend):
             await _init_reranker_backend("local")
+        assert get_reranker() is None
 
     @patch(
         "mnemo_mcp.server.asyncio.to_thread",


### PR DESCRIPTION
## Change
- return call-local reranker backend/model/fallback metadata from memory search
- clear failed cached reranker candidates so reported identity cannot go stale
- document configured-cloud versus local selection behavior
- update live protocol coverage and release wording

## Verification
- targeted reranker/lifespan tests: 43 passed
- full suite: 1755 passed, 5 skipped, 79 deselected
- live add/search/rerank protocol: passed
- Ruff, format, ty, uv lock, and scoped pre-commit: passed

Review state: REVIEW-DEGRADED-PROVIDER-QUOTA; parent and graph review found no blocking issue.