### PR TITLE
fix: isolate Mnemo local protocol replay

### DIFF
--- a/tests/test_live_protocol.py
+++ b/tests/test_live_protocol.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import time
 import warnings
+from pathlib import Path
 
 import pytest
 from mcp import StdioServerParameters
@@ -20,6 +21,93 @@ from mcp.client.session import ClientSession
 from mcp.client.stdio import stdio_client
 
 pytestmark = [pytest.mark.live, pytest.mark.timeout(120)]
+
+
+# Environment names needed to launch ``uv`` and its child process on all
+# supported platforms. Everything else must be supplied explicitly below.
+_PROCESS_ENV_KEYS = (
+    "PATH",
+    "PATHEXT",
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "VIRTUAL_ENV",
+    "UV_PROJECT_ENVIRONMENT",
+)
+
+_KNOWN_PROVIDER_ENV_KEYS = (
+    "API_KEYS",
+    "JINA_API_KEY",
+    "JINA_AI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+    "COHERE_API_KEY",
+    "CO_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "XAI_API_KEY",
+    "GOOGLE_VERTEX_EXPRESS_API_KEY",
+    "GOOGLE_DRIVE_CLIENT_ID",
+    "EMBEDDING_MODELS",
+    "RERANK_MODELS",
+    "LLM_MODELS",
+    "EMBEDDING_MODEL",
+    "RERANK_MODEL",
+    "EMBEDDING_BACKEND",
+    "RERANK_BACKEND",
+    "EMBEDDING_API_BASE",
+    "RERANK_API_BASE",
+    "LLM_API_BASE",
+    "LOCAL_EMBEDDING_MODEL",
+    "LOCAL_RERANK_MODEL",
+    "MCP_RELAY_URL",
+)
+
+
+def _build_local_replay_env(
+    tmp_path: Path,
+    *,
+    cache_dir: Path | str,
+) -> dict[str, str]:
+    """Build a credential-free, temporary environment for a local replay."""
+    parent_by_upper = {name.upper(): value for name, value in os.environ.items()}
+    parent_env = {
+        name: parent_by_upper[name.upper()]
+        for name in _PROCESS_ENV_KEYS
+        if name.upper() in parent_by_upper
+    }
+    local_state = tmp_path / "local-state"
+    config_dir = tmp_path / "local-config"
+    data_dir = tmp_path / "local-data"
+    temp_dir = tmp_path / "local-temp"
+    db_path = tmp_path / "local-test.db"
+    env = {
+        **parent_env,
+        "DB_PATH": str(db_path),
+        "MNEMO_DB_PATH": str(db_path),
+        "LOG_LEVEL": "WARNING",
+        "SYNC_ENABLED": "false",
+        "MCP_TRANSPORT": "stdio",
+        "MEMORY_DB_BACKEND": "sqlite",
+        "MNEMO_DATA_DIR": str(data_dir),
+        "HOME": str(local_state),
+        "USERPROFILE": str(local_state),
+        "XDG_CONFIG_HOME": str(config_dir),
+        "XDG_DATA_HOME": str(data_dir),
+        "LOCALAPPDATA": str(local_state),
+        "APPDATA": str(local_state),
+        "TMP": str(temp_dir),
+        "TEMP": str(temp_dir),
+        "TMPDIR": str(temp_dir),
+        "FASTRETRIEVAL_CACHE_PATH": str(cache_dir),
+        "QWEN3_EMBED_CACHE_PATH": "",
+        "EMBEDDING_DIMS": "0",
+        "RERANK_ENABLED": "true",
+        "DISABLE_LOCAL_EMBED": "false",
+        "DISABLE_LOCAL_RERANK": "false",
+    }
+    env.update(dict.fromkeys(_KNOWN_PROVIDER_ENV_KEYS, ""))
+    return env
 
 
 # ---------------------------------------------------------------------------
@@ -51,16 +139,12 @@ async def mcp_session(tmp_path):
     Suppresses anyio cancel-scope teardown errors that occur when
     pytest-asyncio tears down the event loop in a different task context.
     """
-    db_path = str(tmp_path / "test.db")
+    from fastretrieval import define_cache_dir
+
     server_params = StdioServerParameters(
         command="uv",
         args=["run", "mnemo-mcp"],
-        env={
-            **os.environ,
-            "DB_PATH": db_path,
-            "LOG_LEVEL": "WARNING",
-            "SYNC_ENABLED": "false",
-        },
+        env=_build_local_replay_env(tmp_path, cache_dir=define_cache_dir()),
     )
     try:
         async with stdio_client(server_params) as (read_stream, write_stream):
@@ -85,51 +169,10 @@ async def local_mcp_session(tmp_path):
     """Start mnemo-mcp with deterministic local-only provider selection."""
     from fastretrieval import define_cache_dir
 
-    local_state = tmp_path / "local-state"
-    cache_dir = define_cache_dir()
-    db_path = str(tmp_path / "local-test.db")
-    local_env = {
-        **os.environ,
-        "DB_PATH": db_path,
-        "LOG_LEVEL": "WARNING",
-        "SYNC_ENABLED": "false",
-        "MCP_TRANSPORT": "stdio",
-        "HOME": str(local_state),
-        "USERPROFILE": str(local_state),
-        "XDG_CONFIG_HOME": str(local_state),
-        "LOCALAPPDATA": str(local_state),
-        "APPDATA": str(local_state),
-        "FASTRETRIEVAL_CACHE_PATH": str(cache_dir),
-        "QWEN3_EMBED_CACHE_PATH": "",
-        "API_KEYS": "",
-        "JINA_API_KEY": "",
-        "JINA_AI_API_KEY": "",
-        "GEMINI_API_KEY": "",
-        "GOOGLE_API_KEY": "",
-        "OPENAI_API_KEY": "",
-        "COHERE_API_KEY": "",
-        "CO_API_KEY": "",
-        "ANTHROPIC_API_KEY": "",
-        "XAI_API_KEY": "",
-        "GOOGLE_VERTEX_EXPRESS_API_KEY": "",
-        "GOOGLE_DRIVE_CLIENT_ID": "",
-        "EMBEDDING_MODELS": "",
-        "RERANK_MODELS": "",
-        "LLM_MODELS": "",
-        "EMBEDDING_MODEL": "",
-        "RERANK_MODEL": "",
-        "EMBEDDING_BACKEND": "",
-        "RERANK_BACKEND": "",
-        "EMBEDDING_API_BASE": "",
-        "RERANK_API_BASE": "",
-        "LLM_API_BASE": "",
-        "LOCAL_EMBEDDING_MODEL": "",
-        "LOCAL_RERANK_MODEL": "",
-        "EMBEDDING_DIMS": "0",
-        "RERANK_ENABLED": "true",
-        "DISABLE_LOCAL_EMBED": "false",
-        "DISABLE_LOCAL_RERANK": "false",
-    }
+    local_env = _build_local_replay_env(
+        tmp_path,
+        cache_dir=define_cache_dir(),
+    )
     subprocess.run(
         [
             "uv",

--- a/tests/test_live_protocol_env.py
+++ b/tests/test_live_protocol_env.py
@@ -1,0 +1,95 @@
+"""Unit tests for the local live-protocol child environment builder."""
+
+import os
+from pathlib import Path
+
+from test_live_protocol import (
+    _KNOWN_PROVIDER_ENV_KEYS,
+    _PROCESS_ENV_KEYS,
+    _build_local_replay_env,
+)
+
+
+def test_replay_env_retains_only_process_launch_essentials(monkeypatch, tmp_path):
+    expected = {name: f"essential-{name.lower()}" for name in _PROCESS_ENV_KEYS}
+    for name, value in expected.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("UNEXPECTED_PARENT_SECRET", "must-not-propagate")
+
+    env = _build_local_replay_env(
+        tmp_path,
+        cache_dir=tmp_path / "model-cache",
+    )
+
+    assert {name: env[name] for name in _PROCESS_ENV_KEYS} == expected
+    assert "UNEXPECTED_PARENT_SECRET" not in env
+    assert set(env) <= set(_PROCESS_ENV_KEYS) | set(_KNOWN_PROVIDER_ENV_KEYS) | {
+        "DB_PATH",
+        "MNEMO_DB_PATH",
+        "LOG_LEVEL",
+        "SYNC_ENABLED",
+        "MCP_TRANSPORT",
+        "MEMORY_DB_BACKEND",
+        "MNEMO_DATA_DIR",
+        "HOME",
+        "USERPROFILE",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "LOCALAPPDATA",
+        "APPDATA",
+        "TMP",
+        "TEMP",
+        "TMPDIR",
+        "FASTRETRIEVAL_CACHE_PATH",
+        "QWEN3_EMBED_CACHE_PATH",
+        "EMBEDDING_DIMS",
+        "RERANK_ENABLED",
+        "DISABLE_LOCAL_EMBED",
+        "DISABLE_LOCAL_RERANK",
+    }
+    assert env["DB_PATH"] == env["MNEMO_DB_PATH"]
+
+
+def test_replay_env_empties_known_provider_values(monkeypatch, tmp_path):
+    for name in _KNOWN_PROVIDER_ENV_KEYS:
+        monkeypatch.setenv(name, f"parent-{name.lower()}")
+
+    env = _build_local_replay_env(tmp_path, cache_dir=tmp_path / "cache")
+
+    assert all(env[name] == "" for name in _KNOWN_PROVIDER_ENV_KEYS)
+
+
+def test_replay_env_forces_temporary_local_offline_boundary(tmp_path):
+    root = tmp_path.resolve()
+    env = _build_local_replay_env(tmp_path, cache_dir=tmp_path / "cache")
+
+    assert env["DB_PATH"] == str(root / "local-test.db")
+    for name in (
+        "HOME",
+        "USERPROFILE",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "LOCALAPPDATA",
+        "APPDATA",
+        "TMP",
+        "TEMP",
+        "TMPDIR",
+    ):
+        assert Path(env[name]).is_relative_to(root)
+    assert env["SYNC_ENABLED"] == "false"
+    assert env["MEMORY_DB_BACKEND"] == "sqlite"
+    assert env["EMBEDDING_MODELS"] == ""
+    assert env["RERANK_MODELS"] == ""
+    assert env["LLM_MODELS"] == ""
+    assert env["EMBEDDING_BACKEND"] == ""
+    assert env["RERANK_BACKEND"] == ""
+    assert env["DISABLE_LOCAL_EMBED"] == "false"
+    assert env["DISABLE_LOCAL_RERANK"] == "false"
+
+
+def test_replay_env_does_not_mutate_caller_environment(tmp_path):
+    before = dict(os.environ)
+
+    _build_local_replay_env(tmp_path, cache_dir=tmp_path / "cache")
+
+    assert dict(os.environ) == before


### PR DESCRIPTION
## Problem
The local protocol replay fixtures inherited the full parent environment, allowing provider/model/relay credentials or cloud routing to leak into an acceptance run.

## Change
- build an allowlisted child environment containing only process-launch essentials
- force temporary DB, home, config, data, and temp paths
- force SQLite, stdio, sync-off, and local embedding/reranking
- empty known provider, model, API, and relay variables
- use the same boundary for both protocol fixtures

## Verification
- `uv run pytest -q tests/test_live_protocol_env.py` — 4 passed
- `uv run ruff check tests/test_live_protocol.py tests/test_live_protocol_env.py` — passed
- `uv run pytest -q tests/test_live_protocol.py::TestMeta::test_list_tools -m live` — 1 passed (actual stdio server launch)
- pre-commit: gitleaks, Ruff, type check, pytest, Unicode/file guards — passed

No provider/cloud call was made; the live smoke used the local allowlisted child process only.