### PR TITLE
fix: preserve embedding query and document roles

### DIFF
--- a/src/mnemo_mcp/embedder.py
+++ b/src/mnemo_mcp/embedder.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from loguru import logger
+
+EmbeddingRole = Literal["document", "query"]
 
 # ---------------------------------------------------------------------------
 # Shared constants
@@ -136,6 +138,8 @@ class EmbeddingBackend(Protocol):
         self,
         texts: list[str],
         dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[list[float]]:
         """Embed a batch of texts. Returns list of embedding vectors."""
         ...
@@ -144,6 +148,8 @@ class EmbeddingBackend(Protocol):
         self,
         text: str,
         dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[float]:
         """Embed a single text. Returns embedding vector."""
         ...
@@ -259,17 +265,25 @@ class CloudEmbeddingBackend:
         # OpenAI-style bare names (text-embedding-3-*) pass through as-is.
         return self.model
 
-    def _build_kwargs(self, dimensions: int | None) -> dict:
+    def _build_kwargs(
+        self, dimensions: int | None, role: EmbeddingRole
+    ) -> dict[str, Any]:
         """Build provider-specific aembedding/embedding kwargs."""
-        kwargs: dict = {}
+        kwargs: dict[str, Any] = {}
         if dimensions:
             kwargs["dimensions"] = dimensions
         if self._provider == "cohere":
-            kwargs["input_type"] = "search_document"
+            kwargs["input_type"] = (
+                "search_query" if role == "query" else "search_document"
+            )
         return kwargs
 
     async def _call_provider(
-        self, texts: list[str], dimensions: int | None = None
+        self,
+        texts: list[str],
+        dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[list[float]]:
         """Single cloud path via mcp_core.llm (litellm passthrough)."""
         # Lazy import: litellm costs ~1-2s on first import.
@@ -284,12 +298,16 @@ class CloudEmbeddingBackend:
             input=texts,
             api_base=self.api_base or api_base_for_task("EMBEDDING_API_BASE"),
             api_key=self.api_key or api_key_for_model(litellm_model),
-            **self._build_kwargs(dimensions),
+            **self._build_kwargs(dimensions, role),
         )
         return _parse_embeddings(response)
 
     def _call_provider_sync(
-        self, texts: list[str], dimensions: int | None = None
+        self,
+        texts: list[str],
+        dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[list[float]]:
         """Sync cloud path for ``check_available`` (sync mirror).
 
@@ -315,7 +333,7 @@ class CloudEmbeddingBackend:
             # loops otherwise multiply the timeout and make a stalled endpoint
             # hold startup open far beyond PROBE_TIMEOUT.
             num_retries=0,
-            **self._build_kwargs(dimensions),
+            **self._build_kwargs(dimensions, role),
         )
         return _parse_embeddings(response)
 
@@ -323,6 +341,8 @@ class CloudEmbeddingBackend:
         self,
         texts: list[str],
         dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[list[float]]:
         """Embed a single batch with retry logic for transient errors.
 
@@ -335,7 +355,7 @@ class CloudEmbeddingBackend:
         last_exc: Exception | None = None
         for attempt in range(MAX_RETRIES):
             try:
-                embeddings = await self._call_provider(texts, use_dimensions)
+                embeddings = await self._call_provider(texts, use_dimensions, role=role)
 
                 # Truncate locally if server returned more dims than requested
                 if dimensions and embeddings and len(embeddings[0]) > dimensions:
@@ -376,13 +396,15 @@ class CloudEmbeddingBackend:
         self,
         texts: list[str],
         dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[list[float]]:
         """Embed texts with auto batch splitting."""
         if not texts:
             return []
 
         if len(texts) <= self.MAX_BATCH_SIZE:
-            return await self._embed_batch_inner(texts, dimensions)
+            return await self._embed_batch_inner(texts, dimensions, role=role)
 
         # Split into batches
         total_batches = (len(texts) + self.MAX_BATCH_SIZE - 1) // self.MAX_BATCH_SIZE
@@ -404,7 +426,7 @@ class CloudEmbeddingBackend:
                 logger.debug(
                     f"Embedding batch {batch_idx + 1}/{total_batches}: {len(batch_texts)} texts"
                 )
-                res = await self._embed_batch_inner(batch_texts, dimensions)
+                res = await self._embed_batch_inner(batch_texts, dimensions, role=role)
                 return batch_idx, res
 
         tasks = []
@@ -426,9 +448,11 @@ class CloudEmbeddingBackend:
         self,
         text: str,
         dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[float]:
         """Embed a single text."""
-        results = await self.embed_texts([text], dimensions)
+        results = await self.embed_texts([text], dimensions, role=role)
         return results[0]
 
     def check_available(self) -> int:
@@ -438,7 +462,7 @@ class CloudEmbeddingBackend:
         failures (debug) so users know when their keys are wrong.
         """
         try:
-            embeddings = self._call_provider_sync(["test"])
+            embeddings = self._call_provider_sync(["test"], role="document")
             if embeddings:
                 dim = len(embeddings[0])
                 logger.info(f"Embedding model {self.model} available (dims={dim})")
@@ -502,19 +526,22 @@ class Qwen3EmbedBackend:
         self,
         texts: list[str],
         dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[list[float]]:
         """Embed texts using local ONNX model (runs in thread)."""
         if not texts:
             return []
 
-        def _embed():
+        def _embed() -> list[list[float]]:
             model = self._get_model()
-            # Pass dim to model.embed() so MRL truncation happens BEFORE L2-normalization
-            kwargs = {}
-            if dimensions and dimensions > 0:
-                kwargs["dim"] = dimensions
-            embeddings = list(model.embed(texts, **kwargs))
-            return [emb.tolist() for emb in embeddings]
+            kwargs = {"dim": dimensions} if dimensions and dimensions > 0 else {}
+            if role == "query":
+                return [
+                    list(model.query_embed(text, **kwargs))[0].tolist()
+                    for text in texts
+                ]
+            return [embedding.tolist() for embedding in model.embed(texts, **kwargs)]
 
         return await asyncio.to_thread(_embed)
 
@@ -522,27 +549,12 @@ class Qwen3EmbedBackend:
         self,
         text: str,
         dimensions: int | None = None,
+        *,
+        role: EmbeddingRole = "document",
     ) -> list[float]:
-        """Embed a single text (document/passage)."""
-        results = await self.embed_texts([text], dimensions)
+        """Embed a single text."""
+        results = await self.embed_texts([text], dimensions, role=role)
         return results[0]
-
-    async def embed_single_query(
-        self,
-        text: str,
-        dimensions: int | None = None,
-    ) -> list[float]:
-        """Embed a query with instruction prefix (asymmetric retrieval)."""
-
-        def _query():
-            model = self._get_model()
-            kwargs = {}
-            if dimensions and dimensions > 0:
-                kwargs["dim"] = dimensions
-            result = list(model.query_embed(text, **kwargs))
-            return result[0].tolist()
-
-        return await asyncio.to_thread(_query)
 
     def check_available(self) -> int:
         """Kiểm tra runtime fastretrieval cục bộ có hoạt động hay không."""
@@ -613,7 +625,9 @@ async def embed_single(
     dimensions: int | None = None,
     api_base: str | None = None,
     api_key: str | None = None,
+    *,
+    role: EmbeddingRole = "document",
 ) -> list[float]:
     """Embed a single text (legacy interface)."""
     backend = CloudEmbeddingBackend(model, api_base=api_base, api_key=api_key)
-    return await backend.embed_single(text, dimensions)
+    return await backend.embed_single(text, dimensions, role=role)

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -633,13 +633,13 @@ async def _embed(
         text: Text to embed.
         model: Embedding model name.
         dims: Target dimensions (MRL truncation).
-        is_query: If True, use query_embed for instruction-aware asymmetric
-            retrieval (Qwen3). Document embeddings stay raw.
+        is_query: If True, request the backend's query role for asymmetric
+            retrieval. Document embeddings use the document role.
     """
     if not model:
         return None
 
-    from mnemo_mcp.embedder import Qwen3EmbedBackend, get_backend
+    from mnemo_mcp.embedder import EmbeddingRole, get_backend
 
     backend = backend or get_backend()
     if backend is None:
@@ -647,10 +647,9 @@ async def _embed(
         logger.warning(f"Embedding backend not initialized despite model={model}")
         return None
 
+    role: EmbeddingRole = "query" if is_query else "document"
     try:
-        if is_query and isinstance(backend, Qwen3EmbedBackend):
-            return await backend.embed_single_query(text, dims)
-        return await backend.embed_single(text, dims)
+        return await backend.embed_single(text, dims, role=role)
     except Exception as e:
         from mnemo_mcp.embedder import _is_retryable
 
@@ -2126,6 +2125,7 @@ async def _handle_config_backfill(
             vectors = await backend.embed_texts(
                 [str(row["content"]) for row in usable],
                 embedding_dims,
+                role="document",
             )
         except Exception as exc:
             logger.warning(f"Embedding backfill batch failed: {exc}")

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -1,6 +1,41 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+from mnemo_mcp.server import _handle_config_backfill
 from scripts.backfill_embeddings import backfill
+
+
+async def test_server_backfill_passes_document_role_and_aligns_vectors():
+    db = MagicMock()
+    db.rows_without_vectors.side_effect = [
+        [
+            {"id": "a", "content": "alpha"},
+            {"id": "b", "content": "beta"},
+        ],
+        [],
+    ]
+    backend = MagicMock()
+    backend.embed_texts = AsyncMock(return_value=[[0.1], [0.2]])
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {
+        "db": db,
+        "embedding_model": None,
+        "embedding_dims": 1,
+    }
+
+    with patch(
+        "mnemo_mcp.server._get_request_embedding",
+        return_value=("some-model", backend),
+    ):
+        result = await _handle_config_backfill(ctx, batch_size=2)
+
+    assert result["embedded"] == 2
+    backend.embed_texts.assert_awaited_once_with(["alpha", "beta"], 1, role="document")
+    assert db.write_vector.call_args_list == [
+        call("a", [0.1]),
+        call("b", [0.2]),
+    ]
 
 
 class _FakeDB:

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -109,6 +109,24 @@ class TestCloudEmbeddingBackend:
             result = await backend.embed_texts(["test"], dimensions=768)
         assert len(result[0]) == 768
 
+    async def test_dimensions_fallback_preserves_query_role(self):
+        """Dropping unsupported dimensions does not change the provider role."""
+        unsupported_err = Exception("output_dimension is not supported for this model")
+        mock = AsyncMock(side_effect=[unsupported_err, _resp([0.1] * 1024)])
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="embed-multilingual-v3.0", api_key="key"
+            )
+            result = await backend.embed_texts(["test"], dimensions=768, role="query")
+
+        assert len(result[0]) == 768
+        assert [call.kwargs["input_type"] for call in mock.call_args_list] == [
+            "search_query",
+            "search_query",
+        ]
+        assert mock.call_args_list[0].kwargs["dimensions"] == 768
+        assert "dimensions" not in mock.call_args_list[1].kwargs
+
     async def test_local_truncation_when_server_returns_more(self):
         """Truncates locally when server returns more dims than requested."""
         mock = _async_resp([0.1] * 3072)
@@ -127,8 +145,11 @@ class TestCloudEmbeddingBackend:
     def test_check_available_returns_dims(self):
         mock = MagicMock(return_value=_resp([0.1, 0.2]))
         with patch("mcp_core.llm.embedding", mock):
-            backend = CloudEmbeddingBackend(api_key="key")
+            backend = CloudEmbeddingBackend(
+                model="embed-multilingual-v3.0", api_key="key"
+            )
             assert backend.check_available() == 2
+        assert mock.call_args.kwargs["input_type"] == "search_document"
 
     def test_check_available_error(self):
         mock = MagicMock(side_effect=Exception("Model not found"))
@@ -449,3 +470,16 @@ class TestLegacyCompat:
                 "test", "embed-multilingual-v3.0", api_key="key"
             )
         assert result == [0.1, 0.2]
+
+    async def test_embed_single_legacy_forwards_role(self):
+        with patch.object(
+            CloudEmbeddingBackend,
+            "embed_single",
+            new=AsyncMock(return_value=[0.1, 0.2]),
+        ) as mock:
+            result = await embed_single(
+                "test", "embed-multilingual-v3.0", api_key="key", role="query"
+            )
+
+        assert result == [0.1, 0.2]
+        mock.assert_awaited_once_with("test", None, role="query")

--- a/tests/test_embedder_coverage.py
+++ b/tests/test_embedder_coverage.py
@@ -1,7 +1,7 @@
 """Additional tests for mnemo_mcp.embedder -- covering uncovered lines.
 
 Targets: CloudEmbeddingBackend with api_base/api_key, Qwen3EmbedBackend._get_model,
-embed_texts inner function, embed_single_query, check_available result empty.
+embed_texts inner function, query role, check_available result empty.
 """
 
 from types import SimpleNamespace
@@ -118,14 +118,14 @@ class TestQwen3EmbedTextsInner:
 
 
 # ---------------------------------------------------------------------------
-# Qwen3EmbedBackend.embed_single_query
+# Qwen3EmbedBackend query role
 # ---------------------------------------------------------------------------
 
 
-class TestQwen3EmbedSingleQuery:
+class TestQwen3EmbedQueryRole:
     @patch("fastretrieval.TextEmbedding")
-    async def test_embed_single_query(self, mock_te):
-        """embed_single_query uses query_embed for asymmetric retrieval."""
+    async def test_embed_texts_query_role(self, mock_te):
+        """query role uses query_embed for asymmetric retrieval."""
         mock_emb = MagicMock()
         mock_emb.tolist.return_value = [0.5, 0.6, 0.7]
 
@@ -134,14 +134,15 @@ class TestQwen3EmbedSingleQuery:
         mock_te.return_value = mock_model
 
         backend = Qwen3EmbedBackend()
-        result = await backend.embed_single_query("search query")
+        result = await backend.embed_texts(["search query"], role="query")
 
-        assert result == [0.5, 0.6, 0.7]
-        mock_model.query_embed.assert_called_once()
+        assert result == [[0.5, 0.6, 0.7]]
+        mock_model.query_embed.assert_called_once_with("search query")
+        mock_model.embed.assert_not_called()
 
     @patch("fastretrieval.TextEmbedding")
-    async def test_embed_single_query_with_dimensions(self, mock_te):
-        """embed_single_query passes dim parameter."""
+    async def test_embed_single_with_query_role_and_dimensions(self, mock_te):
+        """embed_single with query role passes the dimension to query_embed."""
         mock_emb = MagicMock()
         mock_emb.tolist.return_value = [0.5, 0.6]
 
@@ -150,11 +151,10 @@ class TestQwen3EmbedSingleQuery:
         mock_te.return_value = mock_model
 
         backend = Qwen3EmbedBackend()
-        result = await backend.embed_single_query("query", dimensions=256)
+        result = await backend.embed_single("query", dimensions=256, role="query")
 
         assert result == [0.5, 0.6]
-        call_kwargs = mock_model.query_embed.call_args
-        assert call_kwargs[1].get("dim") == 256
+        mock_model.query_embed.assert_called_once_with("query", dim=256)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_embedder_dimension_recovery.py
+++ b/tests/test_embedder_dimension_recovery.py
@@ -38,7 +38,10 @@ class TestDimensionRecovery:
         # First call should have had dimensions=512
         # Second call should have had dimensions=None
         mock_call_provider.assert_has_calls(
-            [call(["hello"], 512), call(["hello"], None)]
+            [
+                call(["hello"], 512, role="document"),
+                call(["hello"], None, role="document"),
+            ]
         )
 
     @patch(

--- a/tests/test_embedder_providers.py
+++ b/tests/test_embedder_providers.py
@@ -217,6 +217,30 @@ class TestCloudEmbeddingPassthrough:
         assert mock.call_args.kwargs["input_type"] == "search_document"
         assert mock.call_args.kwargs["model"] == "cohere/embed-multilingual-v3.0"
 
+    async def test_cohere_query_uses_search_query(self):
+        response = _embedding_response([0.1, 0.2])
+        with patch(
+            "mcp_core.llm.aembedding", new=AsyncMock(return_value=response)
+        ) as call:
+            backend = CloudEmbeddingBackend(
+                "cohere/embed-multilingual-v3.0", api_key="key"
+            )
+            result = await backend.embed_single("find this", role="query")
+
+        assert result == [0.1, 0.2]
+        assert call.call_args.kwargs["input_type"] == "search_query"
+
+    async def test_non_cohere_query_adds_no_provider_role_kwarg(self):
+        response = _embedding_response([0.3])
+        with patch(
+            "mcp_core.llm.aembedding", new=AsyncMock(return_value=response)
+        ) as call:
+            backend = CloudEmbeddingBackend("jina_ai/jina-embeddings-v3", api_key="key")
+            await backend.embed_single("find this", role="query")
+
+        assert "input_type" not in call.call_args.kwargs
+        assert "role" not in call.call_args.kwargs
+
     async def test_none_data_returns_empty(self):
         """resp.data=None is guarded and yields []."""
         mock = AsyncMock(return_value=SimpleNamespace(data=None))

--- a/tests/test_embedder_silent_dims.py
+++ b/tests/test_embedder_silent_dims.py
@@ -80,7 +80,8 @@ class TestWrappedDimsRejectionRecovery:
         # hide the defect.
         native_dim = 1536
 
-        async def fake_call(texts, dimensions=None):
+        async def fake_call(texts, dimensions=None, *, role):
+            assert role == "document"
             if dimensions is not None:
                 raise _wrapped_422()
             return [[0.1] * native_dim for _ in texts]
@@ -98,11 +99,14 @@ class TestWrappedDimsRejectionRecovery:
         assert mock_call.call_count == 2
         assert mock_call.call_args_list[0].args[1] == 768
         assert mock_call.call_args_list[1].args[1] is None
+        assert mock_call.call_args_list[0].kwargs["role"] == "document"
+        assert mock_call.call_args_list[1].kwargs["role"] == "document"
 
     async def test_wrapped_422_is_not_retried_with_same_dims(self):
         # If the fallback did NOT fire, the buggy code would retry MAX_RETRIES
         # times with the same rejected dims. Assert it does NOT.
-        async def always_reject(texts, dimensions=None):
+        async def always_reject(texts, dimensions=None, *, role):
+            assert role == "document"
             raise _wrapped_422()
 
         backend = CloudEmbeddingBackend(model="cohere/embed-v4.0")
@@ -118,3 +122,5 @@ class TestWrappedDimsRejectionRecovery:
         assert mock_call.call_count < MAX_RETRIES + 1
         assert mock_call.call_args_list[0].args[1] == 768
         assert mock_call.call_args_list[1].args[1] is None
+        assert mock_call.call_args_list[0].kwargs["role"] == "document"
+        assert mock_call.call_args_list[1].kwargs["role"] == "document"

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -94,27 +94,40 @@ class TestEmbed:
             with pytest.raises(Exception, match="does not exist"):
                 await _embed("test text", "some-model", 768)
 
-    async def test_embed_with_qwen3_query(self):
-        """Uses query_embed for Qwen3 backend with is_query=True."""
-        from mnemo_mcp.embedder import Qwen3EmbedBackend
+    async def test_embed_query_passes_query_role(self):
+        """Any backend receives the query role for search embeddings."""
+        mock_backend = MagicMock()
+        mock_backend.embed_single = AsyncMock(return_value=[0.1, 0.2])
 
-        mock_backend = MagicMock(spec=Qwen3EmbedBackend)
-        mock_backend.embed_single_query = AsyncMock(return_value=[0.1, 0.2])
+        result = await _embed(
+            "search query",
+            "some-model",
+            768,
+            is_query=True,
+            backend=mock_backend,
+        )
 
-        with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
-            result = await _embed("search query", "__local__", 768, is_query=True)
-            assert result == [0.1, 0.2]
-            mock_backend.embed_single_query.assert_called_once_with("search query", 768)
+        assert result == [0.1, 0.2]
+        mock_backend.embed_single.assert_awaited_once_with(
+            "search query", 768, role="query"
+        )
 
-    async def test_embed_with_non_qwen3_query(self):
-        """Uses regular embed_single for non-Qwen3 backends even with is_query."""
+    async def test_embed_document_passes_document_role(self):
+        """Any backend receives the document role for stored embeddings."""
         mock_backend = MagicMock()
         mock_backend.embed_single = AsyncMock(return_value=[0.3, 0.4])
 
-        with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
-            result = await _embed("search query", "some-model", 768, is_query=True)
-            assert result == [0.3, 0.4]
-            mock_backend.embed_single.assert_called_once_with("search query", 768)
+        result = await _embed(
+            "memory body",
+            "some-model",
+            768,
+            backend=mock_backend,
+        )
+
+        assert result == [0.3, 0.4]
+        mock_backend.embed_single.assert_awaited_once_with(
+            "memory body", 768, role="document"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +234,9 @@ class TestConfigSync:
             "failed": 0,
         }
         assert db.write_vector.call_count == 2
-        backend.embed_texts.assert_awaited_once()
+        backend.embed_texts.assert_awaited_once_with(
+            ["first memory", "second memory"], 1536, role="document"
+        )
 
     @pytest.mark.parametrize("batch_size", [0, 101, True, "2"])
     async def test_config_backfill_rejects_unbounded_batch_size(

--- a/tests/test_server_embed.py
+++ b/tests/test_server_embed.py
@@ -1,9 +1,8 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from litellm.exceptions import APIConnectionError, RateLimitError
 
-from mnemo_mcp.embedder import Qwen3EmbedBackend
 from mnemo_mcp.server import _embed
 
 
@@ -15,40 +14,29 @@ async def test_embed_no_model():
 
 
 @pytest.mark.asyncio
-async def test_embed_with_generic_backend_query():
-    """Test _embed with a generic backend (not Qwen3) calls embed_single even for query."""
-    mock_backend = AsyncMock()
-    mock_backend.embed_single.return_value = [0.1, 0.2]
+async def test_embed_query_passes_query_role_to_any_backend():
+    """Queries use the protocol role rather than a concrete backend branch."""
+    backend = MagicMock()
+    backend.embed_single = AsyncMock(return_value=[0.3, 0.4])
 
-    with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
-        # Call with is_query=True
-        result = await _embed("text", "model", 768, is_query=True)
-        assert result == [0.1, 0.2]
-        mock_backend.embed_single.assert_called_once_with("text", 768)
+    result = await _embed(
+        "search query", "some-model", 768, is_query=True, backend=backend
+    )
 
-
-@pytest.mark.asyncio
-async def test_embed_with_qwen3_backend_query():
-    """Test _embed with Qwen3Backend and is_query=True calls embed_single_query."""
-    mock_backend = AsyncMock(spec=Qwen3EmbedBackend)
-    mock_backend.embed_single_query.return_value = [0.3, 0.4]
-
-    with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
-        result = await _embed("text", "model", 768, is_query=True)
-        assert result == [0.3, 0.4]
-        mock_backend.embed_single_query.assert_called_once_with("text", 768)
+    assert result == [0.3, 0.4]
+    backend.embed_single.assert_awaited_once_with("search query", 768, role="query")
 
 
 @pytest.mark.asyncio
-async def test_embed_with_qwen3_backend_doc():
-    """Test _embed with Qwen3Backend and is_query=False calls embed_single."""
-    mock_backend = AsyncMock(spec=Qwen3EmbedBackend)
-    mock_backend.embed_single.return_value = [0.5, 0.6]
+async def test_embed_document_passes_document_role():
+    """Documents use the protocol's explicit document role."""
+    backend = MagicMock()
+    backend.embed_single = AsyncMock(return_value=[0.5, 0.6])
 
-    with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
-        result = await _embed("text", "model", 768, is_query=False)
-        assert result == [0.5, 0.6]
-        mock_backend.embed_single.assert_called_once_with("text", 768)
+    result = await _embed("memory body", "some-model", 768, backend=backend)
+
+    assert result == [0.5, 0.6]
+    backend.embed_single.assert_awaited_once_with("memory body", 768, role="document")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Spec

Implements approved Phase 2 design §4 (embedding role as an internal contract) and §7 review boundary.

## Change

- thread keyword-only `EmbeddingRole` through protocol, cloud/Qwen backends, batches, retries, dimension fallback, server, and backfill
- map Cohere document/query intent to `search_document`/`search_query`
- use Qwen `embed`/`query_embed` by role and remove the concrete-backend query branch
- preserve existing transient/permanent error policy and MCP surface

## Verification

- focused role/caller suite — 164 passed, 11 existing SQLAlchemy deprecation warnings
- Ruff check and format-check on all 10 changed files — passed
- `uv run pytest -q` — 1763 passed, 5 skipped, 79 deselected
- behavioral smoke — Cohere role mapping read back correctly; local backend called `embed` for documents and `query_embed` for queries
- final cross-repository review — spec PASS; no Critical/Important finding

## Non-goals

No MCP argument/env rename, public Fastretrieval or mcp-core API change, provider/auth route, embedding-space migration, new tool/action, or stable promotion.

## Rollback

Revert this PR's squash commit; no stored embedding migration or configuration rollback is required.