### PR TITLE
fix: prevent information disclosure in validation errors

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -57,3 +57,8 @@ section the heading level puts it in.
 **Vulnerability:** Raw exception strings from `KeyError` (e.g., `str(e)`) were exposed in the JSON response payload of `sync_now` and `import_passport` tool handlers when an unknown or misconfigured backend was requested.
 **Learning:** Returning exception details like `str(e)` from `KeyError` directly to the client can leak sensitive internal configuration keys or backend structure details. Exception strings should be masked with generic error messages in API responses.
 **Prevention:** Catch `KeyError` without an `as e` binding, log the exception securely on the server using `logger.exception()`, and return a generic error message (e.g., `"backend configuration incomplete"`) to the client.
+
+## 2026-08-30 - Prevent Information Disclosure in ValueError Validation Errors
+**Vulnerability:** Raw exception strings from `ValueError` (e.g., `str(e)`) were exposed in the JSON response payload of `_handle_add`, `_handle_update`, and `_handle_capture` tool handlers when validation failed for reasons other than content length limits.
+**Learning:** Returning exception details like `str(e)` from `ValueError` directly to the client can leak sensitive internal constraints or processing logic. Exception strings should be masked with generic error messages in API responses unless they relate to necessary client-side validation feedback (like 'content exceeds limit').
+**Prevention:** Catch `ValueError`, and if the error string does not contain benign validation feedback (like 'exceeds limit'), return a generic error message (e.g., `"validation failed"`) to the client and rely on server-side logging.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -718,8 +718,12 @@ async def _handle_add(
             embedding=embedding,
         )
     except ValueError as e:
+        msg = str(e)
+        if "exceeds limit" not in msg:
+            logger.exception("Validation failed in _handle_add")
+            msg = "validation failed"
         return {
-            "error": str(e),
+            "error": msg,
             "suggestion": "Ensure input parameters meet validation rules.",
         }
     except Exception:
@@ -1014,8 +1018,12 @@ async def _handle_update(
             embedding=embedding,
         )
     except ValueError as e:
+        msg = str(e)
+        if "exceeds limit" not in msg:
+            logger.exception("Validation failed in _handle_update")
+            msg = "validation failed"
         return {
-            "error": str(e),
+            "error": msg,
             "suggestion": "Check input parameters for invalid types or values.",
         }
     except Exception:
@@ -1249,6 +1257,9 @@ async def _handle_capture(
                     f"Pick a context_type from {sorted(CONTEXT_TYPES)}."
                 )
             return resp
+        if "exceeds limit" not in msg:
+            logger.exception("Validation failed in _handle_capture")
+            msg = "validation failed"
         return {"error": msg, "suggestion": "Check payload length and constraints."}
     except Exception:
         logger.exception("Unexpected error in _handle_capture")

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.9.0"
+version = "2.10.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR implements a security fix to prevent information disclosure vulnerabilities in the API response payloads. Previously, raw exception strings (`str(e)`) from `ValueError` were returned directly to the client when handling tool requests, which could inadvertently expose internal constraints, processing logic, or unhandled exceptions masquerading as validation issues. 

This change securely catches `ValueError`, checks for known, benign client-side validation feedback (like 'exceeds limit' for payload length checks), and falls back to a generic `"validation failed"` message for all other exceptions. The actual error details are securely logged server-side for debugging. A corresponding entry was added to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [6871445917170270191](https://jules.google.com/task/6871445917170270191) started by @n24q02m*