### PR TITLE
fix(deps): pin mcp[cli]<2 for FastMCP v1 SDK compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = "==3.13.*"
 dependencies = [
     # MCP Server
-    "mcp[cli]",
+    "mcp[cli]<2",
     # HTTP Client (for embedding API calls)
     "httpx",
     # Config

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.9.0"
+version = "2.10.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1132,7 +1132,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "idna", specifier = ">=3.19" },
     { name = "loguru" },
-    { name = "mcp", extras = ["cli"] },
+    { name = "mcp", extras = ["cli"], specifier = "<2" },
     { name = "n24q02m-mcp-core", extras = ["llm"], specifier = "==1.23.2" },
     { name = "pydantic" },
     { name = "pydantic-settings", specifier = ">=2.14.2,<2.15" },


### PR DESCRIPTION
## Problem
mcp[cli] dependency is unpinned; next lock refresh can float to mcp 2.x which removes mcp.server.fastmcp (FastMCP renamed MCPServer) and breaks all imports.

## Fix
Pin mcp[cli]<2 matching fleet parity (wet-mcp #1746, crg already >=1.29.1,<2). In-place relock: mcp 1.29.0 -> 1.29.1, minimal diff.

## Verification
CI Lint & Test.