### PR TITLE
feat: add suggestion when as_of parameter is missing

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,6 @@ reviewable surface here is -- the `error`, `suggestion` and `note` strings in
 `src/mnemo_mcp/server.py` and the tool docs under `src/mnemo_mcp/docs/` -- and
 that a decision to change nothing belongs in this file as an entry. Read this
 file before opening anything against this repository.
+## 2026-08-01 - Missing Suggestion in as_of Action
+**Learning:** Found an opportunity to improve Developer Experience (DX). The `memory(action="as_of")` call lacked an explicit check for the `as_of` parameter and threw a raw unhelpful error or skipped downstream. Added an explicit validation step returning a structured error and suggestion.
+**Action:** When adding validation checks for API endpoints in purely backend MCP servers, ensure they return a structured dictionary containing both an `error` message and a `suggestion` for actionable recovery.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1411,6 +1411,13 @@ async def _handle_as_of(
     """
     db, _, _ = _get_ctx(ctx)
 
+    if not as_of:
+        return {
+            "error": "as_of is required for action='as_of'",
+            "example": "action='as_of', as_of='2026-01-15T00:00:00'",
+            "suggestion": "Provide the 'as_of' parameter as an ISO timestamp.",
+        }
+
     if isinstance(limit, int):
         limit = max(1, min(limit, 100))
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -163,6 +163,13 @@ class TestMemoryAsOf:
         assert result["count"] == 1
         assert result["as_of"] == "2026-01-15T00:00:00"
 
+    async def test_as_of_missing_param_returns_error_and_suggestion(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = await memory(action="as_of", ctx=ctx)
+        assert "error" in result
+        assert "suggestion" in result
+        assert "as_of is required" in result["error"]
+
     async def test_as_of_param_with_other_action_errors_not_ignores(self, ctx_with_db):
         ctx, _ = ctx_with_db
         result = await memory(


### PR DESCRIPTION
Improves the error response for the `memory(action="as_of")` tool when the required `as_of` parameter is omitted. Returns a structured JSON response with an actionable `suggestion` string instead of a raw error.

---
*PR created automatically by Jules for task [12256196925173907335](https://jules.google.com/task/12256196925173907335) started by @n24q02m*