### PR TITLE
fix(deps): update n24q02m/better-semantic-release action to v1.6.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
       # BEFORE the real run creates a git tag or GitHub Release. Same action + SHA and
       # same prerelease inputs as the real step, run against the same untouched checkout,
       # so the computed version is identical.
-      - uses: n24q02m/better-semantic-release@274ef643f3758549bc9e2c616505bd1c32a83409 # v1.5.0
+      - uses: n24q02m/better-semantic-release@69319fae1169b6ee7b89565c7b54b55d1531d42e # v1.6.0
         id: dryrun
         with:
           github_token: ${{ steps.app-token.outputs.token }}
@@ -122,7 +122,7 @@ jobs:
           echo "::error::Could not verify whether ${PKG} ${COMPUTED_VERSION} exists on PyPI: ${URL} returned HTTP '${status:-<no response>}' (expected 200 or 404). Refusing to proceed so a genuine collision cannot slip through as a false 'free'. Re-run the release once the registry is reachable."
           exit 1
 
-      - uses: n24q02m/better-semantic-release@274ef643f3758549bc9e2c616505bd1c32a83409 # v1.5.0
+      - uses: n24q02m/better-semantic-release@69319fae1169b6ee7b89565c7b54b55d1531d42e # v1.6.0
         id: release
         with:
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Updates both BSR release action callsites from the v1.5.0 commit pin to the released v1.6.0 commit pin.

Focused proof: workflow YAML parsed successfully; exactly two v1.6.0 pins and zero v1.5.0 pins.