### PR TITLE
feat: 🎨 Palette: Add actionable suggestions to empty entity and temporal query results

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,6 @@ reviewable surface here is -- the `error`, `suggestion` and `note` strings in
 `src/mnemo_mcp/server.py` and the tool docs under `src/mnemo_mcp/docs/` -- and
 that a decision to change nothing belongs in this file as an entry. Read this
 file before opening anything against this repository.
+## 2024-05-18 - Actionable suggestions for empty sets across API
+**Learning:** Tools returning empty sets (like entity queries or historical timelines) without `suggestion` strings degrade DX by leaving developers guessing what to do next.
+**Action:** Ensure all tool handlers returning lists or graph outputs include an actionable `suggestion` string (e.g., "Try a broader search...") when the result set is empty, not just the primary search/list tools.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1371,11 +1371,16 @@ async def _handle_entity_search(
     rows = await asyncio.to_thread(
         entity_search, db, name=name, entity_type=entity_type, limit=limit
     )
-    return {
+    response: dict = {
         "count": len(rows),
         "results": [_format_memory(r) for r in rows],
         "matched_name": name,
     }
+    if len(rows) == 0:
+        response["suggestion"] = (
+            "No entities found. Try a broader search or verify the entity name/type."
+        )
+    return response
 
 
 async def _handle_entity_graph(
@@ -1398,6 +1403,10 @@ async def _handle_entity_graph(
     result = await asyncio.to_thread(
         entity_graph, db, entity_id=entity_id, name=name, depth=depth, limit=limit
     )
+    if not result.get("nodes"):
+        result["suggestion"] = (
+            "No entity graph found. Verify the entity_id or name exists."
+        )
     return result
 
 
@@ -1417,11 +1426,16 @@ async def _handle_as_of(
     from mnemo_mcp.temporal.queries import memories_as_of
 
     rows = await asyncio.to_thread(memories_as_of, db, as_of, limit)
-    return {
+    response: dict = {
         "memories": [_format_memory(m) for m in rows],
         "count": len(rows),
         "as_of": as_of,
     }
+    if len(rows) == 0:
+        response["suggestion"] = (
+            "No memories found at that point in time. Try adjusting the as_of timestamp."
+        )
+    return response
 
 
 async def _handle_history(
@@ -1441,11 +1455,16 @@ async def _handle_history(
     from mnemo_mcp.temporal.queries import history_for_entity
 
     timeline = await asyncio.to_thread(history_for_entity, db, entity_id)
-    return {
+    response: dict = {
         "entity_id": entity_id,
         "count": len(timeline),
         "timeline": [_format_memory(m) for m in timeline],
     }
+    if len(timeline) == 0:
+        response["suggestion"] = (
+            "No history found for this entity. Verify the entity_id exists and has linked memories."
+        )
+    return response
 
 
 async def _handle_consolidate(


### PR DESCRIPTION
💡 What: Added actionable `suggestion` properties to the JSON responses for `entity_search`, `entity_graph`, `as_of`, and `history` tools when they return empty result sets.
🎯 Why: Returning empty lists/graphs without guidance leaves developers and agents guessing whether their query was malformed, the entity doesn't exist, or there's a typo. Adding explicit suggestions improves Developer Experience (DX) and meets UX constraints for this backend repo.
📸 Before/After: 
Before: `{"count": 0, "results": [], "matched_name": "unknown"}`
After: `{"count": 0, "results": [], "matched_name": "unknown", "suggestion": "No entities found. Try a broader search or verify the entity name/type."}`
♿ Accessibility: Improves API usability and conceptual accessibility for developers and automated agents consuming the MCP interface.

---
*PR created automatically by Jules for task [8179727620724911410](https://jules.google.com/task/8179727620724911410) started by @n24q02m*