### PR TITLE
fix: reconcile mnemo MCP execution packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Run your own mnemo instance serverless on Cloudflare (Containers + D1 + Vectoriz
    index, and the encrypted credential store:
    ```
    wrangler d1 create mnemo-memories
-   wrangler vectorize create mnemo-memory-vectors --dimensions 768 --metric cosine
+   wrangler vectorize create mnemo-memory-vectors-1536 --dimensions 1536 --metric cosine
    wrangler kv namespace create mnemo-kv
    ```
    Paste the returned D1 database ID and KV namespace ID into `wrangler.jsonc` (the
@@ -279,17 +279,20 @@ Run your own mnemo instance serverless on Cloudflare (Containers + D1 + Vectoriz
    wrangler secret put CREDENTIAL_SECRET              # per-user vault key (encrypts the cf-kv credential store)
    wrangler secret put MCP_RELAY_PASSWORD             # shared password gating the browser setup form
    wrangler secret put MCP_DCR_SERVER_SECRET          # required once PUBLIC_URL is set (multi-user, per-JWT-sub)
-   wrangler secret put JINA_AI_API_KEY                # EMBEDDING_MODELS + RERANK_MODELS (cloud embed / rerank)
-   wrangler secret put GOOGLE_VERTEX_EXPRESS_API_KEY  # LLM_MODELS (graph extraction, importance, consolidation)
    ```
 6. `wrangler deploy` and complete setup in the browser relay form at your Worker domain.
+   Save each subject's models, endpoints and provider keys there, not in Worker
+   environment variables. The managed route uses Minimax-free completion and
+   paid Cohere embedding/reranking through Cloudflare AI Gateway; see the
+   [per-task configuration](src/mnemo_mcp/docs/config.md#remote-model-routing).
 
 Storage maps to Cloudflare via `MCP_STORAGE_BACKEND=cf-kv` (credentials / tokens, encrypted),
 `MEMORY_DB_BACKEND=cf-d1` (the memories database + FTS5 full-text; unset or `sqlite`
 keeps the local SQLite file at `DB_PATH`), and Vectorize (embeddings,
-cosine). Embedding and reranking are forced cloud through the `EMBEDDING_MODELS` /
-`RERANK_MODELS` chains (`jina_ai/...`) so the container never downloads Fastretrieval's
-local Qwen3 ONNX models, and graph / LLM features run through the `LLM_MODELS` chain (`vertex_express/...`).
+cosine). Cloud embedding, reranking and completion resolve per authenticated
+subject. Remote startup does not probe shared provider credentials or download
+local Fastretrieval models. Missing subject configuration never selects a
+process-wide provider/model fallback.
 
 ### Authority & Sync Boundary
 
@@ -297,7 +300,7 @@ On Cloudflare deployments, **Cloudflare D1 + Vectorize + KV** is the sole produc
 - **D1** (`MEMORY_DB_BACKEND=cf-d1`): Authoritative storage for memory rows, metadata, bitemporal valid ranges, and FTS5 search.
 - **Vectorize** (`MCP_VECTORIZE_IDX`): Dense vector index for semantic similarity search.
 - **KV** (`MCP_STORAGE_BACKEND=cf-kv`): Encrypted per-user credential and session store.
-- **Sync boundary** (`SYNC_ENABLED=false`): Production Cloudflare deployments pin legacy Google Drive sync off; Cloudflare serves as the live authority.
+- **Sync boundary**: `MEMORY_DB_BACKEND=cf-d1` disables Google Drive OAuth and all external sync paths even if `SYNC_ENABLED` is toggled on or stale S3/Google settings remain. `SYNC_ENABLED=false` independently disables sync on non-CF deployments.
 - **Local & self-host bootstrap**: Local stdio (`~/.mnemo-mcp/memories.db`) and self-hosted instances retain optional passport sync (Google Drive Device Code OAuth or S3/R2/B2) for workstation migration.
 
 ## Trust Model

--- a/docs/passport.md
+++ b/docs/passport.md
@@ -25,8 +25,10 @@ profile:
 - Cloudflare **D1** owns memory rows and FTS5 search.
 - Cloudflare **Vectorize** owns dense vectors.
 - Cloudflare **KV** owns encrypted per-user credentials and session state.
-- `SYNC_ENABLED=false` keeps the legacy database-file Google Drive sync path
-  disabled.
+- `MEMORY_DB_BACKEND=cf-d1` disables external sync, even when stale bucket
+  or Google client settings remain. `SYNC_ENABLED=false` is a second hard
+  off switch for non-CF deployments too. Startup, relay/device-code setup,
+  direct Google auth, manual sync and the passport scheduler use this rule.
 
 Do not treat a historical Drive `memories.db` or export as a complete inventory
 of current production memories. Any Drive cleanup is a separate exact-root,
@@ -45,11 +47,14 @@ multi-mirror semantics: operator picks ONE backend per deployment.
 
 Resolution rule (`sync.resolve_active_backend`):
 
+- `MEMORY_DB_BACKEND=cf-d1` or `SYNC_ENABLED=false` → **disabled**.
+  Google OAuth is not requested and no external sync task is started.
+  Explicit `sync_now` / `import_passport` requests return `status="disabled"`.
 - `SYNC_S3_BUCKET` is set (env var OR pydantic `settings.sync_s3_bucket`) →
   active backend = **S3**. GDrive Device Code OAuth is **disabled** at
   startup; the relay form does NOT prompt for a Google account.
-- Otherwise → active backend = **GDrive**. The relay form drives the
-  Device Code flow for the end-user's Google account.
+- Otherwise, with sync enabled → active backend = **GDrive**. The relay
+  form drives the Device Code flow for the end-user's Google account.
 
 Env var takes precedence over the pydantic field so an operator can
 override a persisted bucket from `config.enc` without rewriting it.

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -15,12 +15,13 @@ mnemo/imagine/email CF harnesses):
                        harness also submits the model and endpoint routing explicitly.
   4. token          -- POST /token (code + verifier) -> bearer JWT
   5. tool call      -- config(status) + unique add/search/delete round-trip and a
-                       multi-candidate semantic/rerank probe over D1/Vectorize.
+                       three-row semantic/rerank + completion probe in an isolated category.
 
-Secrets from env: Gate A login password MCP_RELAY_PASSWORD (or RELAY_PW) from skret
-/oci-vm-prod/prod (infra-shared); default provider values come from the configured
-per-sub relay. With --cohere-cf-gateway, CF_AIG_BASE and CF_AIG_TOKEN come from the
-existing /n24q02m/dev namespace and are mapped to the approved Cohere gateway route.
+Secrets from env: Gate A login password MCP_RELAY_PASSWORD (or RELAY_PW) from
+the MCP-owned skret /mcp-stack/prod namespace; no legacy namespace fallback.
+With --cohere-cf-gateway, CF_AIG_BASE and CF_AIG_TOKEN configure per-sub
+Minimax-free completion and paid Cohere embedding/reranking. Obtain explicit
+bounded spend authorization and isolate the fixture before executing this mode.
 
 Run modes:
   (default)            full flow: config(status) + search and multi-candidate
@@ -35,9 +36,9 @@ Run modes:
                        before B creates and searches its own marker.
 
 Examples:
-  skret run -e prod --path=/oci-vm-prod/prod -- \
-    skret run -e prod --path=/mnemo-mcp/prod -- \
-      python scripts/cf_full_flow.py
+  skret run -e prod --path=/mcp-stack/prod -- \
+    skret run -e dev --path=/n24q02m/dev -- \
+      python scripts/cf_full_flow.py --cohere-cf-gateway
   ... -- python scripts/cf_full_flow.py --endpoint https://mnemo.n24q02m.com
   ... -- python scripts/cf_full_flow.py --save-only
   ... -- python scripts/cf_full_flow.py --auth-only
@@ -67,12 +68,12 @@ MARKER = "cf-canary-probe-mnemo"
 
 
 def _configure_cohere_cf_gateway() -> None:
-    """Configure the approved Cohere-through-CF-AI-Gateway BYOK route.
+    """Configure Minimax-free completion and paid Cohere through CF AI Gateway.
 
-    The deployed relay must receive the gateway token as ``COHERE_API_KEY`` so
-    LiteLLM sends it as the gateway ``Authorization`` credential.  The
-    gateway then selects Cohere from the explicit endpoint paths.  Clear
-    competing provider/model values first so a stale local or skret export
+    The relay receives the gateway token in both provider-key fields so the
+    library sends it as the gateway Authorization credential. Explicit endpoint
+    paths select OpenRouter or Cohere; there is no direct-provider fallback.
+    Clear competing provider/model values first so a stale local or skret export
     cannot silently route the probe to Jina or another provider.
     """
     base = os.environ.get("CF_AIG_BASE", "").strip().rstrip("/")
@@ -88,6 +89,14 @@ def _configure_cohere_cf_gateway() -> None:
         "GEMINI_API_KEY",
         "OPENAI_API_KEY",
         "XAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_VERTEX_EXPRESS_API_KEY",
+        "GOOGLE_API_KEY",
+        "JINA_AI_API_KEY_DIRECT",
+        "VERTEX_EXPRESS_KEY_DIRECT",
+        "COHERE_API_KEY_DIRECT",
+        "XAI_API_KEY_DIRECT",
         "COHERE_API_KEY",
         "EMBEDDING_MODELS",
         "EMBEDDING_API_BASE",
@@ -105,36 +114,9 @@ def _configure_cohere_cf_gateway() -> None:
             "EMBEDDING_API_BASE": f"{base}/cohere/v2/embed",
             "RERANK_MODELS": "cohere/rerank-v4.0-fast",
             "RERANK_API_BASE": f"{base}/cohere",
-        }
-    )
-
-
-def _configure_cohere_direct() -> None:
-    """Configure direct Cohere API route using a skret-provided alias."""
-    token = (
-        os.environ.get("COHERE_API_KEY_DIRECT") or os.environ.get("COHERE_API_KEY", "")
-    ).strip()
-    if not token:
-        raise SystemExit("COHERE_API_KEY_DIRECT (or COHERE_API_KEY) is required.")
-    for env_name in (
-        "JINA_AI_API_KEY",
-        "GEMINI_API_KEY",
-        "OPENAI_API_KEY",
-        "XAI_API_KEY",
-        "COHERE_API_KEY",
-        "EMBEDDING_MODELS",
-        "EMBEDDING_API_BASE",
-        "RERANK_MODELS",
-        "RERANK_API_BASE",
-        "LLM_MODELS",
-        "LLM_API_BASE",
-    ):
-        os.environ.pop(env_name, None)
-    os.environ.update(
-        {
-            "COHERE_API_KEY": token,
-            "EMBEDDING_MODELS": "cohere/embed-multilingual-v3.0",
-            "RERANK_MODELS": "cohere/rerank-multilingual-v3.0",
+            "OPENROUTER_API_KEY": token,
+            "LLM_MODELS": "openrouter/minimax/minimax-m3:free",
+            "LLM_API_BASE": f"{base}/openrouter/v1",
         }
     )
 
@@ -144,8 +126,8 @@ def _password() -> str:
     if not pw:
         raise SystemExit(
             "MCP_RELAY_PASSWORD (or RELAY_PW) is required for the password-grant "
-            "login gate. It lives in skret /oci-vm-prod/prod (infra-shared), NOT "
-            "/mnemo-mcp/prod -- compose both namespaces."
+            "login gate. Resolve only the MCP-owned /mcp-stack/prod namespace; "
+            "no legacy namespace fallback is allowed."
         )
     return pw
 
@@ -157,6 +139,7 @@ def _creds() -> dict[str, str]:
         ("JINA_AI_API_KEY", "JINA_AI_API_KEY_DIRECT"),
         ("GEMINI_API_KEY", "VERTEX_EXPRESS_KEY_DIRECT"),
         ("OPENAI_API_KEY", None),
+        ("OPENROUTER_API_KEY", None),
         ("COHERE_API_KEY", "COHERE_API_KEY_DIRECT"),
         ("XAI_API_KEY", "XAI_API_KEY_DIRECT"),
     ):
@@ -194,17 +177,15 @@ def get_token(endpoint: str, creds: dict[str, str], *, save_retries: int = 8) ->
     form payload (provider and routing settings are explicit for Mnemo)."""
     import httpx  # lazy: keep --help importable without httpx installed
 
-    last: Exception | None = None
     for attempt in range(save_retries):
         try:
             return _get_token_once(httpx, endpoint, creds)
-        except _SaveRetry as e:
-            last = e
+        except _SaveRetry:
             print(
-                f"get_token: save 500 (interception race), retry {attempt + 1}/{save_retries}"
+                f"get_token: credential save HTTP 500, retry {attempt + 1}/{save_retries}"
             )
             time.sleep(3)
-    raise RuntimeError(f"get_token failed after {save_retries} retries: {last}")
+    raise RuntimeError(f"get_token failed after {save_retries} credential-save retries")
 
 
 def _get_token_once(httpx, endpoint: str, creds: dict[str, str]) -> str:
@@ -252,10 +233,10 @@ def _get_token_once(httpx, endpoint: str, creds: dict[str, str]) -> str:
         nonce = m.group(1)
         sub = c.post(f"{endpoint}/authorize", params={"nonce": nonce}, json=creds)
         if sub.status_code == 500 and "save credentials" in sub.text:
-            raise _SaveRetry(sub.text[:120])
-        assert sub.status_code == 200, (sub.status_code, sub.text[:300])
+            raise _SaveRetry("Credential save returned HTTP 500")
+        assert sub.status_code == 200, f"Credential save HTTP {sub.status_code}"
         data = sub.json()
-        assert data.get("ok"), data
+        assert data.get("ok"), "Credential save did not acknowledge success"
         code = urllib.parse.parse_qs(urllib.parse.urlparse(data["redirect_url"]).query)[
             "code"
         ][0]
@@ -269,7 +250,7 @@ def _get_token_once(httpx, endpoint: str, creds: dict[str, str]) -> str:
                 "code_verifier": verifier,
             },
         )
-        assert tok.status_code == 200, (tok.status_code, tok.text[:300])
+        assert tok.status_code == 200, f"Token exchange HTTP {tok.status_code}"
         return tok.json()["access_token"]
 
 
@@ -290,10 +271,10 @@ async def _call(s, label, tool, args, *, retries=20, delay=8):
                 print(f"{label}: awaiting_setup (KV propagating) try {i + 1}/{retries}")
                 await asyncio.sleep(delay)
                 continue
-            print(f"{label} OK:", txt[:320].replace("\n", " "))
+            print(f"{label}: response received")
             return txt
         except Exception as e:
-            print(f"{label} ERR:", repr(e)[:300])
+            print(f"{label} ERR:", type(e).__name__)
             return None
     print(f"{label}: gave up after {retries} tries")
     return None
@@ -314,12 +295,10 @@ def _tool_payload(txt: str | None, operation: str) -> dict:
     assert txt is not None, f"{operation} returned no payload"
     try:
         payload = _json.loads(txt)
-    except _json.JSONDecodeError as exc:
-        raise AssertionError(
-            f"{operation} returned non-JSON payload: {txt[:300]}"
-        ) from exc
+    except _json.JSONDecodeError:
+        raise AssertionError(f"{operation} returned non-JSON payload") from None
     assert isinstance(payload, dict), f"{operation} returned a non-object payload"
-    assert not payload.get("error"), f"{operation} returned an error: {txt[:300]}"
+    assert not payload.get("error"), f"{operation} returned an error"
     return payload
 
 
@@ -348,7 +327,6 @@ def _assert_search_resolved(
 ) -> None:
     """Require the exact added memory and its unique marker in search results."""
     results = _search_results(txt)
-    result_text = _json.dumps(results, ensure_ascii=False)
     assert any(
         (
             memory_id is None
@@ -357,7 +335,7 @@ def _assert_search_resolved(
         )
         and marker in _json.dumps(result, ensure_ascii=False)
         for result in results
-    ), f"search_memory did not return the added marker/id: {result_text[:300]}"
+    ), "search_memory did not return the exact added marker/id"
     print(
         "ASSERT OK: add_memory -> search_memory round-trip resolved over the CF deployment."
     )
@@ -368,8 +346,7 @@ def _assert_search_absent(txt: str | None, marker: str) -> None:
     results = _search_results(txt)
     result_text = _json.dumps(results, ensure_ascii=False)
     assert marker not in result_text, (
-        "isolation failure: search_memory returned sub A marker for sub B: "
-        f"{result_text[:300]}"
+        "isolation failure: search_memory returned sub A marker for sub B"
     )
     print("ASSERT OK: sub B search did not return sub A marker.")
 
@@ -378,20 +355,15 @@ def _assert_rerank_payload(txt: str | None, memory_ids: list[str]) -> None:
     """Require a multi-result search to use both embedding and reranking."""
     payload = _tool_payload(txt, "search_memory(rerank)")
     assert payload.get("semantic") is True, (
-        "multi-candidate search did not report semantic=true: "
-        f"{_json.dumps(payload, ensure_ascii=False)[:400]}"
+        "multi-candidate search did not report semantic=true"
     )
     assert payload.get("reranked") is True, (
-        "multi-candidate search did not report reranked=true: "
-        f"{_json.dumps(payload, ensure_ascii=False)[:400]}"
+        "multi-candidate search did not report reranked=true"
     )
     results = _search_results(txt)
     result_ids = {result.get("id") or result.get("memory_id") for result in results}
     missing = [memory_id for memory_id in memory_ids if memory_id not in result_ids]
-    assert not missing, (
-        "multi-candidate search omitted exact probe ids: "
-        f"{missing}; results={_json.dumps(results, ensure_ascii=False)[:400]}"
-    )
+    assert not missing, f"multi-candidate search omitted {len(missing)} exact probe ids"
     assert len(results) >= 2, "rerank probe returned fewer than two results"
     print(
         "ASSERT OK: multi-candidate search reported semantic=true and "
@@ -420,7 +392,7 @@ async def _delete_memory(s, memory_id: str) -> None:
     payload = _tool_payload(txt, "delete_memory")
     deleted_id = _memory_id(payload, "delete_memory")
     assert payload.get("status") == "deleted" and deleted_id == memory_id, (
-        f"delete_memory did not delete exact memory id {memory_id!r}: {txt[:300]}"
+        "delete_memory did not delete the exact fixture memory"
     )
 
 
@@ -456,10 +428,10 @@ async def _run_search(
         if not cleanup and memory_id is not None:
             try:
                 await _delete_memory(s, memory_id)
-            except Exception as cleanup_exc:
+            except Exception:
                 raise RuntimeError(
-                    f"probe failed and cleanup failed for memory id {memory_id!r}"
-                ) from cleanup_exc
+                    "probe failed and exact fixture cleanup also failed"
+                ) from None
         raise
     finally:
         if cleanup and memory_id is not None:
@@ -467,7 +439,7 @@ async def _run_search(
 
 
 async def _run_rerank(s) -> None:
-    """Exercise semantic retrieval and reranking with three related memories."""
+    """Probe retrieval, reranking and completion using one isolated three-row fixture."""
     marker = _new_marker("rerank")
     query = "enterprise multi-user team deployment backlog"
     contents = (
@@ -484,11 +456,13 @@ async def _run_rerank(s) -> None:
                 s,
                 f"ADD_RERANK_{index}",
                 "add_memory",
-                {"content": content},
+                {"content": content, "category": marker},
             )
             add_payload = _tool_payload(add_txt, "add_memory(rerank)")
             memory_id = _memory_id(add_payload, "add_memory(rerank)")
-            assert add_payload.get("status") in {"saved", "created"}, add_payload
+            assert add_payload.get("status") in {"saved", "created"}, (
+                "Fixture add failed"
+            )
             memory_ids.append(memory_id)
 
         search_txt = await _call(
@@ -497,10 +471,27 @@ async def _run_rerank(s) -> None:
             "search_memory",
             {
                 "query": query,
+                "category": marker,
                 "limit": 8,
             },
         )
         _assert_rerank_payload(search_txt, memory_ids)
+        completion_txt = await _call(
+            s,
+            "COMPLETION",
+            "consolidate_memories",
+            {"category": marker},
+        )
+        completion = _tool_payload(completion_txt, "consolidate_memories")
+        assert completion.get("status") == "consolidated", "Completion did not succeed"
+        assert completion.get("original_count") == len(memory_ids), (
+            "Completion escaped fixture scope"
+        )
+        summary = completion.get("summary")
+        assert isinstance(summary, str) and summary.strip(), (
+            "Completion returned no summary"
+        )
+        print("ASSERT OK: completion returned a summary for the isolated fixture.")
     finally:
         for memory_id in reversed(memory_ids):
             await _delete_memory(s, memory_id)
@@ -512,7 +503,7 @@ def _token_file() -> Path:
 
 async def run_full(endpoint: str) -> None:
     token = get_token(endpoint, _creds())
-    print("TOKEN OK len=", len(token), "sub=", _sub_of(token))
+    print("TOKEN OK: bearer acquired")
     transport, ClientSession = await _session(endpoint, token)
     async with transport as (r, w, _), ClientSession(r, w) as s:
         await s.initialize()
@@ -530,7 +521,7 @@ async def run_backfill(endpoint: str, batch_size: int = 32) -> None:
     if not 1 <= batch_size <= 100:
         raise SystemExit("--batch-size must be between 1 and 100")
     token = get_token(endpoint, _creds())
-    print("TOKEN OK len=", len(token), "sub=", _sub_of(token))
+    print("TOKEN OK: bearer acquired")
     transport, ClientSession = await _session(endpoint, token)
     async with transport as (r, w, _), ClientSession(r, w) as s:
         await s.initialize()
@@ -543,9 +534,15 @@ async def run_backfill(endpoint: str, batch_size: int = 32) -> None:
             delay=2,
         )
     payload = _tool_payload(txt, "config(backfill_embeddings)")
-    assert payload.get("status") == "completed", payload
-    assert payload.get("failed") == 0, payload
-    print("BACKFILL PASS:", _json.dumps(payload, sort_keys=True))
+    assert payload.get("status") == "completed", "Backfill did not complete"
+    assert payload.get("failed") == 0, "Backfill reported failed rows"
+    counts = {
+        key: payload.get(key) for key in ("scanned", "embedded", "skipped", "failed")
+    }
+    assert all(type(value) is int for value in counts.values()), (
+        "Invalid backfill counts"
+    )
+    print("BACKFILL PASS:", _json.dumps(counts, sort_keys=True))
 
 
 async def run_save_only(endpoint: str) -> None:
@@ -557,11 +554,7 @@ async def run_save_only(endpoint: str) -> None:
     # Dump the EXACT token so --auth-only replays the SAME JWT sub (relay-login mints
     # a fresh random sub per /authorize).
     _token_file().write_text(token)
-    print(
-        "SAVE-ONLY OK: sub configured=",
-        _sub_of(token),
-        "(token dumped for --auth-only)",
-    )
+    print("SAVE-ONLY OK: exact bearer saved locally for --auth-only")
 
 
 async def run_auth_only(endpoint: str) -> None:
@@ -569,7 +562,7 @@ async def run_auth_only(endpoint: str) -> None:
     if not tok_path.exists():
         raise SystemExit("No dumped token -- run --save-only first.")
     token = tok_path.read_text().strip()
-    print("AUTH-ONLY: replaying saved token for sub=", _sub_of(token))
+    print("AUTH-ONLY: replaying saved bearer")
     transport, ClientSession = await _session(endpoint, token)
     async with transport as (r, w, _), ClientSession(r, w) as s:
         await s.initialize()
@@ -583,10 +576,9 @@ async def run_two_sub_isolation(endpoint: str) -> None:
     sub_a = _sub_of(token_a)
     token_b = get_token(endpoint, _creds())
     sub_b = _sub_of(token_b)
-    print(f"sub A={sub_a}  sub B={sub_b}")
     if sub_a == sub_b:
         raise SystemExit(
-            f"ISOLATION INCONCLUSIVE: both flows share sub {sub_a} (cannot test bleed)."
+            "ISOLATION INCONCLUSIVE: both flows share a subject (cannot test bleed)."
         )
     print("TWO-SUB: distinct bearer subjects acquired; testing marker isolation.")
     marker_a = _new_marker("isolation-a")
@@ -640,14 +632,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--cohere-cf-gateway",
         action="store_true",
         help=(
-            "Use the existing CF_AIG_TOKEN as Cohere BYOK through CF_AIG_BASE; "
-            "clears competing provider/model env values without logging secrets."
+            "Use CF_AIG_TOKEN through CF_AIG_BASE for Minimax-free completion "
+            "and paid Cohere embedding/rerank; clears competing routes."
         ),
-    )
-    p.add_argument(
-        "--cohere-direct",
-        action="store_true",
-        help="Use COHERE_API_KEY_DIRECT with LiteLLM direct Cohere route.",
     )
     mode = p.add_mutually_exclusive_group()
     mode.add_argument(
@@ -686,8 +673,6 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.cohere_cf_gateway:
         _configure_cohere_cf_gateway()
-    elif getattr(args, "cohere_direct", False):
-        _configure_cohere_direct()
 
     if args.save_only:
         asyncio.run(run_save_only(args.endpoint))
@@ -703,4 +688,9 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        # Provider/transport exception text can contain credentials or memory data.
+        print(f"FULL FLOW FAILED: {type(exc).__name__}", file=sys.stderr)
+        sys.exit(1)

--- a/src/mnemo_mcp/compression.py
+++ b/src/mnemo_mcp/compression.py
@@ -18,10 +18,9 @@ Behaviour:
    tiktoken cl100k_base (matches OpenAI / Anthropic Claude estimates closely
    enough for the 3x reduction metric). On empty / failed response -> the
    pipeline degrades to the graceful skip path.
-3. **Env override** -> ``COMPRESSION_PROVIDER`` and ``COMPRESSION_MODEL`` win
-   over the auto-detect priority order in :func:`mnemo_mcp.llm.detect_provider`
-   (Task 3 of the Phase 2 plan). ``COMPRESSION_ENABLED=false`` skips the
-   pipeline entirely.
+3. **Local env override** -> ``COMPRESSION_PROVIDER`` and ``COMPRESSION_MODEL``
+   apply only to single-user/local calls. Authenticated subjects use their own
+   completion configuration. ``COMPRESSION_ENABLED=false`` skips the pipeline.
 
 The module exposes the canonical prompt as :data:`COMPRESSION_PROMPT` so the
 fact-retention benchmark fixture can keep both prompt and ground-truth aligned
@@ -79,7 +78,11 @@ def _env_compression_enabled() -> bool:
 
 
 def _resolve_provider(explicit: str | None) -> str | None:
-    """Pick provider: explicit arg > COMPRESSION_PROVIDER env > auto-detect."""
+    """Use the subject's chain remotely; preserve explicit/local env overrides."""
+    from mnemo_mcp.credential_state import get_current_sub
+
+    if get_current_sub() is not None:
+        return detect_provider()
     if explicit:
         return explicit
     env = os.environ.get("COMPRESSION_PROVIDER", "").strip()
@@ -89,7 +92,11 @@ def _resolve_provider(explicit: str | None) -> str | None:
 
 
 def _resolve_model(provider: str, explicit: str | None) -> str:
-    """Pick model: explicit arg > COMPRESSION_MODEL env > provider default."""
+    """Use the subject's chain remotely; preserve explicit/local env overrides."""
+    from mnemo_mcp.credential_state import get_current_sub
+
+    if get_current_sub() is not None:
+        return get_default_model(provider)
     if explicit:
         return explicit
     env = os.environ.get("COMPRESSION_MODEL", "").strip()

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -327,6 +327,7 @@ class Settings(BaseSettings):
                 "GEMINI_API_KEY",
                 "GOOGLE_API_KEY",
                 "OPENAI_API_KEY",
+                "OPENROUTER_API_KEY",
                 "COHERE_API_KEY",
                 "CO_API_KEY",
                 "XAI_API_KEY",

--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -43,6 +43,7 @@ CLOUD_KEYS = [
     "JINA_AI_API_KEY",
     "GEMINI_API_KEY",
     "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
     "COHERE_API_KEY",
     "ANTHROPIC_API_KEY",
     "XAI_API_KEY",
@@ -83,6 +84,7 @@ LLM_PROVIDER_KEYS = (
     "GEMINI_API_KEY",
     "GOOGLE_API_KEY",
     "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
     "ANTHROPIC_API_KEY",
     "XAI_API_KEY",
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
@@ -104,12 +106,11 @@ def set_current_sub(sub: str | None) -> None:
 
 
 def get_current_sub() -> str | None:
-    """Return the per-request JWT sub if any, else ``None``.
-
-    ``None`` indicates stdio mode or single-user HTTP -- callers should read
-    credentials from environment variables.
-    """
-    return _current_sub.get()
+    """Return the request subject, rejecting an unscoped remote request."""
+    sub = _current_sub.get()
+    if not sub and os.environ.get("PUBLIC_URL"):
+        raise RuntimeError("JWT sub is required for multi-user credentials")
+    return sub
 
 
 def credentials_for_current_request() -> dict[str, str]:
@@ -122,7 +123,7 @@ def credentials_for_current_request() -> dict[str, str]:
     ``os.environ`` filtered to ``CLOUD_KEYS`` so callers never see unrelated
     process env.
     """
-    sub = _current_sub.get()
+    sub = get_current_sub()
     if sub is None:
         return {k: v for k, v in os.environ.items() if k in CLOUD_KEYS and v}
     return read_for_sub(sub)
@@ -136,7 +137,7 @@ def detect_llm_provider_key() -> str | None:
     ``GOOGLE_API_KEY`` Gemini alias. Keeping this policy in one helper prevents
     graph and LLM availability gates from diverging.
     """
-    sub = _current_sub.get()
+    sub = get_current_sub()
     credentials = credentials_for_current_request()
     for key in LLM_PROVIDER_KEYS:
         if credentials.get(key):
@@ -158,7 +159,7 @@ def api_key_for_model(model: str) -> str | None:
     the result is passed explicitly to mcp_core. With no sub, ``None`` keeps
     the existing litellm environment fallback for single-user/stdio mode.
     """
-    if _current_sub.get() is None:
+    if get_current_sub() is None:
         return None
 
     from mcp_core.llm.providers import key_env_for_model
@@ -182,9 +183,12 @@ def api_base_for_task(env_key: str) -> str | None:
     the existing env-driven behavior because mcp-core does not know Mnemo's
     ``*_API_BASE`` names by itself.
     """
-    if _current_sub.get() is None:
+    if get_current_sub() is None:
         return os.environ.get(env_key) or None
-    return credentials_for_current_request().get(env_key) or None
+    api_base = credentials_for_current_request().get(env_key)
+    if not api_base:
+        raise RuntimeError(f"{env_key} is required for the current subject")
+    return api_base
 
 
 def model_chain_for_task(task: str, fallback: str | None = None) -> list[str]:
@@ -200,7 +204,7 @@ def model_chain_for_task(task: str, fallback: str | None = None) -> list[str]:
     if key is None:
         raise ValueError(f"Unknown model-chain task: {task}")
 
-    sub = _current_sub.get()
+    sub = get_current_sub()
     if sub is None:
         raw: object = os.environ.get(key, "")
         if not raw and fallback is not None:
@@ -583,22 +587,15 @@ def _trigger_gdrive_flow(
 ) -> dict | None:
     """Trigger GDrive OAuth Device Code flow if configured.
 
-    Gated by :func:`mnemo_mcp.sync.resolve_active_backend` (XOR design):
-    in S3 mode (``SYNC_S3_BUCKET`` set, Method 2/3 docker deploy) we
-    SKIP the GDrive flow entirely — the operator wired S3 credentials at
-    container spawn and end-users authenticating with cloud API keys via
-    the relay form should NOT be prompted for a Google Drive account on
-    top of that.
+    The deployment resolver disables this flow for Cloudflare D1, disabled
+    sync, and operator-configured S3. Local Google Drive remains opt-in via
+    the existing relay flow.
     """
-    try:
-        from mnemo_mcp.sync import resolve_active_backend
+    from mnemo_mcp.sync import resolve_active_backend
 
-        if resolve_active_backend() == "s3":
-            logger.info("GDrive flow skipped: SYNC_S3_BUCKET set (S3 mode active)")
-            return None
-    except Exception:
-        # Resolver failure is non-fatal — fall through to legacy GDrive path.
-        logger.opt(exception=True).debug("resolve_active_backend failed")
+    if resolve_active_backend() != "gdrive":
+        logger.info("GDrive flow skipped: not the active sync backend")
+        return None
 
     try:
         from mnemo_mcp.config import settings as s

--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -20,6 +20,36 @@ Active actions: `status`, `sync`, `set`, `warmup`, `setup_sync`,
 > raw passphrase is held in process memory only; only the
 > Argon2id-derived hash lands in `config.enc`.
 
+On Cloudflare D1 (`MEMORY_DB_BACKEND=cf-d1`), external sync is disabled
+regardless of stale Google/S3 settings. `sync`, `setup_sync`, `sync_now`
+and `import_passport` return `status="disabled"` without provider access.
+`SYNC_ENABLED=false` applies the same off switch on non-CF deployments.
+
+### Remote model routing
+
+Each authenticated subject saves model, endpoint and provider key per task
+through the relay. Remote calls never inherit another subject or process-wide
+model, endpoint or key; a configured cloud task without its subject endpoint
+fails closed. Empty completion configuration disables enrichment. Local
+single-user mode retains explicit environment configuration and local
+Fastretrieval embedding/reranking.
+Hosted `warmup` probes only the current subject's configured embedding route;
+it never downloads a local model or tests process-wide provider credentials.
+
+For the managed gateway route, select:
+
+| Task | Model | Subject endpoint |
+|---|---|---|
+| Completion (graph, importance, compression) | `openrouter/minimax/minimax-m3:free` | `LLM_API_BASE={gateway}/openrouter/v1` |
+| Embedding | `cohere/embed-v4.0` | `EMBEDDING_API_BASE={gateway}/cohere/v2/embed` |
+| Rerank | `cohere/rerank-v4.0-fast` | `RERANK_API_BASE={gateway}/cohere` |
+
+Store `OPENROUTER_API_KEY` and `COHERE_API_KEY` in the subject relay, not Worker
+environment variables. Cohere calls are paid and require an explicit bounded
+spend authorization. Completion uses only the selected free model; a provider
+error does not select a paid fallback. `COMPRESSION_PROVIDER` and
+`COMPRESSION_MODEL` environment overrides apply only to local single-user mode.
+
 ### `status` - Show current configuration
 
 Returns database stats, the resolved embedding identity, dimensions, availability, and sync status.
@@ -100,7 +130,7 @@ locally so no extra env vars are needed for sync.
 **Parameters:** None (requires `GOOGLE_DRIVE_CLIENT_ID` env var)
 
 **Returns:**
-- `status`: "authenticated" or "error"
+- `status`: "authenticated", "disabled" or "error"
 - `provider`: "google_drive"
 - `token_path`: Path to saved token file
 - `next_steps`: Env vars to set in MCP config
@@ -226,7 +256,7 @@ written to `sync_overrides`.
 
 **Parameters:**
 - `key` (optional): backend name (`"s3"` or `"gdrive"`). Defaults to the
-  first entry of `SYNC_BACKEND` env.
+  deployment resolver; CF D1 and `SYNC_ENABLED=false` disable external sync.
 
 **Returns:**
 - `status`: `"imported"` or `"no_passport"`.
@@ -259,7 +289,8 @@ Configure via environment variables before starting the server:
 | `EMBEDDING_BACKEND` | (auto-detect) | `cloud` (API), `local` (fastretrieval ONNX/GGUF), or empty (auto) |
 | `EMBEDDING_MODEL` | (auto-detect) | Provider model name (e.g. jina-embeddings-v5-text-small) or GGUF model ID |
 | `EMBEDDING_DIMS` | `0` | Embedding dimensions (0 = auto, resolves to 768) |
-| `SYNC_ENABLED` | `true` | Enable Google Drive sync |
+| `SYNC_ENABLED` | `true` | Enable external sync; CF D1 always disables it |
+| `MEMORY_DB_BACKEND` | `sqlite` | `cf-d1` uses D1/Vectorize and suppresses external sync/OAuth |
 | `GOOGLE_DRIVE_CLIENT_ID` | (none) | OAuth client ID for Google Drive |
 | `SYNC_FOLDER` | `mnemo-mcp` | Google Drive folder name |
 | `SYNC_INTERVAL` | `300` | Auto-sync interval (seconds, 0 = manual) |

--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -21,11 +21,13 @@ def _resolve_llm_model(settings_obj) -> str:
     (slash form). A bare =-form first entry (no slash) is normalised to slash
     form so ``_litellm_model`` does not double-prefix it.
     """
-    from mnemo_mcp.credential_state import model_chain_for_task
+    from mnemo_mcp.credential_state import get_current_sub, model_chain_for_task
 
     models = model_chain_for_task("llm", fallback=settings_obj.llm_models)
+    if not models and get_current_sub() is not None:
+        return ""
     raw = models[0] if models else "gemini/gemini-3-flash-preview"
-    return raw.replace("=", "/", 1) if ("=" in raw and "/" not in raw) else raw
+    return raw.replace("=", "/", 1)
 
 
 def _litellm_model(model: str) -> str:
@@ -59,18 +61,33 @@ async def _llm_completion(
     # Lazy import: litellm costs ~1-2s on first import.
     from mcp_core.llm import acompletion
 
-    from mnemo_mcp.credential_state import api_base_for_task, api_key_for_model
+    from mnemo_mcp.credential_state import (
+        api_base_for_task,
+        api_key_for_model,
+        get_current_sub,
+        model_for_task,
+    )
 
     kwargs: dict = {"temperature": temperature, "max_tokens": max_tokens}
     if response_format:
         kwargs["response_format"] = response_format
 
     litellm_model = _litellm_model(model)
+    if get_current_sub() is not None:
+        configured = model_for_task("llm")
+        if not configured:
+            raise RuntimeError("No completion model configured for current subject")
+        litellm_model = configured.replace("=", "/", 1)
+        api_key = api_key_for_model(litellm_model)
+        if not api_key:
+            raise RuntimeError("No completion key configured for current subject")
+    else:
+        api_key = api_key_for_model(litellm_model)
     resp = await acompletion(
         model=litellm_model,
         messages=messages,
         api_base=api_base_for_task("LLM_API_BASE"),
-        api_key=api_key_for_model(litellm_model),
+        api_key=api_key,
         **kwargs,
     )
     return resp.choices[0].message.content or ""

--- a/src/mnemo_mcp/llm.py
+++ b/src/mnemo_mcp/llm.py
@@ -1,26 +1,13 @@
-"""Multi-provider LLM dispatch layer (Phase 1 foundation).
+"""Completion dispatch through the in-process mcp_core.llm library.
 
-Provides a single ``call_llm`` entry point that auto-detects the active
-provider from environment variables and dispatches via ``mcp_core.llm``
-(litellm passthrough). The priority order matches the spec
-(`2026-04-19-mnemo-v2-design.md` §4.2):
+Authenticated subjects select their own model, endpoint and provider key from
+the relay store. Empty subject configuration skips optional enrichment; it never
+inherits process credentials or a default completion model. Local single-user
+callers retain explicit overrides and environment-based provider detection.
 
-    1. Gemini (``GEMINI_API_KEY`` or ``GOOGLE_API_KEY``)
-    2. OpenAI (``OPENAI_API_KEY``)
-    3. Anthropic (``ANTHROPIC_API_KEY``)
-    4. xAI / Grok (``XAI_API_KEY``)
-
-litellm calls each provider's API directly, so ``ANTHROPIC_API_KEY`` now
-works WITHOUT the ``anthropic`` package installed (no native SDK import).
-
-If no provider key is available, ``call_llm`` logs a warning and returns
-``None`` so callers (e.g. the upcoming ``capture`` action's optional fact
-extraction) can gracefully skip LLM-dependent enrichment.
-
-This module is intentionally a *dispatch layer only*. The actual
-fact-extraction prompting / parsing logic is deferred to Phase 2
-(compression). Existing graph-extraction logic continues to live in
-``graph.py`` and is not migrated here in this slice.
+The managed completion route is openrouter/minimax/minimax-m3:free. Library
+dispatch supports explicit gateway endpoints without a standalone proxy server.
+Provider errors return None to optional enrichment callers, not another model.
 """
 
 from __future__ import annotations
@@ -34,6 +21,7 @@ from loguru import logger
 _PROVIDER_ENV_VARS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
     ("gemini", ("GEMINI_API_KEY", "GOOGLE_API_KEY")),
     ("openai", ("OPENAI_API_KEY",)),
+    ("openrouter", ("OPENROUTER_API_KEY",)),
     ("anthropic", ("ANTHROPIC_API_KEY",)),
     ("xai", ("XAI_API_KEY",)),
 )
@@ -45,18 +33,26 @@ _PROVIDER_ENV_VARS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
 _DEFAULT_MODELS: Final[dict[str, str]] = {
     "gemini": "gemini-3-flash-preview",
     "openai": "gpt-5.4-mini-2026-03-17",
+    "openrouter": "minimax/minimax-m3:free",
     "anthropic": "claude-haiku-4-5",
     "xai": "grok-4-fast",
 }
 
 
 def detect_provider() -> str | None:
-    """Return the highest-priority provider with a configured API key.
+    """Resolve an explicit task chain before the local provider-key priority."""
+    from mnemo_mcp.credential_state import (
+        detect_llm_provider_key,
+        get_current_sub,
+        model_for_task,
+    )
 
-    The credential resolver is request-scoped in multi-user mode and
-    environment-backed in single-user/stdio mode.
-    """
-    from mnemo_mcp.credential_state import detect_llm_provider_key
+    configured = model_for_task("llm")
+    if configured:
+        provider, separator, model = configured.replace("=", "/", 1).partition("/")
+        return provider if separator and model else None
+    if get_current_sub() is not None:
+        return None
 
     env_var = detect_llm_provider_key()
     if env_var is None:
@@ -82,7 +78,7 @@ def get_default_model(provider: str) -> str:
     entry for ``provider``, the per-provider sane default from
     ``_DEFAULT_MODELS`` is returned.
     """
-    from mnemo_mcp.credential_state import model_chain_for_task
+    from mnemo_mcp.credential_state import get_current_sub, model_chain_for_task
 
     for pair in model_chain_for_task("llm"):
         for sep in ("=", "/"):
@@ -93,6 +89,9 @@ def get_default_model(provider: str) -> str:
                     if model:
                         return model
                 break
+
+    if get_current_sub() is not None:
+        return ""
 
     return _DEFAULT_MODELS.get(provider, "")
 
@@ -109,11 +108,10 @@ async def call_llm(
 
     Args:
         prompt: User prompt text. Treated as a single-turn user message.
-        provider: Optional explicit provider override
-            (``"gemini"`` / ``"openai"`` / ``"anthropic"`` / ``"xai"``).
-            When ``None`` (the default), auto-detection runs.
-        model: Optional explicit model override. When ``None``, the result of
-            :func:`get_default_model` for the resolved provider is used.
+        provider: Local single-user provider override (including ``"openrouter"``).
+            Authenticated subjects always use their own relay selection.
+        model: Local single-user model override. Otherwise the subject's model,
+            or the local provider default, is used.
         temperature: Sampling temperature passed through to litellm.
         max_tokens: Maximum response tokens to request from the provider.
 
@@ -122,17 +120,26 @@ async def call_llm(
         could be resolved (caller is expected to gracefully skip the
         LLM-dependent enrichment in that case).
     """
-    resolved_provider = provider or detect_provider()
-    if resolved_provider is None:
-        logger.warning(
-            "call_llm: no LLM provider API key found in environment "
-            "(GEMINI_API_KEY / GOOGLE_API_KEY / OPENAI_API_KEY / "
-            "ANTHROPIC_API_KEY / XAI_API_KEY); returning None for graceful skip"
-        )
-        return None
+    from mnemo_mcp.credential_state import get_current_sub, model_for_task
 
-    resolved_model = model or get_default_model(resolved_provider)
-    litellm_model = f"{resolved_provider}/{resolved_model}"
+    subject = get_current_sub()
+    if subject is not None:
+        configured = model_for_task("llm")
+        if not configured:
+            return None
+        litellm_model = configured.replace("=", "/", 1)
+        resolved_provider, separator, resolved_model = litellm_model.partition("/")
+        if not separator or not resolved_model:
+            return None
+    else:
+        resolved_provider = provider or detect_provider()
+        if resolved_provider is None:
+            logger.warning("call_llm: no LLM provider configured; skipping enrichment")
+            return None
+        resolved_model = model or get_default_model(resolved_provider)
+        if not resolved_model:
+            return None
+        litellm_model = f"{resolved_provider}/{resolved_model}"
 
     try:
         # Lazy import: litellm costs ~1-2s on first import.
@@ -140,13 +147,18 @@ async def call_llm(
 
         from mnemo_mcp.credential_state import api_base_for_task, api_key_for_model
 
+        api_key = api_key_for_model(litellm_model)
+        if subject is not None and not api_key:
+            logger.debug("Completion skipped: no key for current subject's model")
+            return None
+
         response = await acompletion(
             model=litellm_model,
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
             max_tokens=max_tokens,
             api_base=api_base_for_task("LLM_API_BASE"),
-            api_key=api_key_for_model(litellm_model),
+            api_key=api_key,
         )
         return response.choices[0].message.content or ""
     except Exception as e:  # pragma: no cover - per-provider runtime guard

--- a/src/mnemo_mcp/relay_schema.py
+++ b/src/mnemo_mcp/relay_schema.py
@@ -11,6 +11,9 @@ deployment-mode decision (env-driven, not user-input):
   / ENDPOINT) + SYNC_PASSPHRASE via docker env → server detects S3
   mode at startup, **disables GDrive flow entirely**, sends encrypted
   bundles to S3-compatible storage.
+- **Cloudflare D1 + Vectorize**: ``MEMORY_DB_BACKEND=cf-d1`` disables
+  external sync and Google Drive OAuth, even with stale bucket/client settings.
+  ``SYNC_ENABLED=false`` also disables both external backends.
 
 The two backends are mutually exclusive at deployment level. See
 docs/passport.md for the full operator runbook.
@@ -20,19 +23,9 @@ from __future__ import annotations
 
 from typing import Any
 
-_EMBEDDING_SUGGESTED = [
-    "jina_ai/jina-embeddings-v5-text-small",
-    "gemini/gemini-embedding-001",
-    "openai/text-embedding-3-large",
-    "cohere/embed-multilingual-v3.0",
-]
-_RERANK_SUGGESTED = ["jina_ai/jina-reranker-v3", "cohere/rerank-v3.5"]
-_LLM_SUGGESTED = [
-    "gemini/gemini-3-flash-preview",
-    "openai/gpt-5.4-mini-2026-03-17",
-    "anthropic/claude-haiku-4-5",
-    "xai/grok-4-fast",
-]
+_EMBEDDING_SUGGESTED = ["cohere/embed-v4.0"]
+_RERANK_SUGGESTED = ["cohere/rerank-v4.0-fast"]
+_LLM_SUGGESTED = ["openrouter/minimax/minimax-m3:free"]
 
 
 def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
@@ -112,7 +105,7 @@ RELAY_SCHEMA: dict[str, Any] = {
         _api_base_field(
             "LLM_API_BASE",
             "LLM endpoint",
-            "Custom endpoint / CF AI Gateway for graph/importance LLM calls.",
+            "Custom endpoint / CF AI Gateway for completion. OpenRouter: {gw}/openrouter/v1",
         ),
         _key_field(
             "JINA_AI_API_KEY", "Jina AI API Key", "jina_...", "https://jina.ai/api-key"
@@ -128,6 +121,12 @@ RELAY_SCHEMA: dict[str, Any] = {
             "OpenAI API Key",
             "sk-...",
             "https://platform.openai.com/api-keys",
+        ),
+        _key_field(
+            "OPENROUTER_API_KEY",
+            "OpenRouter API Key",
+            "OpenRouter API key",
+            "https://openrouter.ai/settings/keys",
         ),
         _key_field(
             "COHERE_API_KEY",
@@ -167,9 +166,10 @@ RELAY_SCHEMA: dict[str, Any] = {
         },
         {
             "label": "Passport Sync (operator-config)",
-            "priority": "S3 (env) XOR Google Drive (default)",
+            "priority": "Disabled on CF D1; otherwise S3 XOR Google Drive",
             "description": (
-                "Mutually exclusive: deployment sets SYNC_S3_BUCKET + "
+                "Cloudflare D1 disables external sync and Google Drive OAuth. "
+                "Otherwise mutually exclusive: deployment sets SYNC_S3_BUCKET + "
                 "SYNC_PASSPHRASE env at docker spawn -> S3 mode with "
                 "encrypted bundles (AES-256-GCM + Argon2id). No S3 env "
                 "-> Google Drive Device Code OAuth via this relay. See "

--- a/src/mnemo_mcp/relay_setup.py
+++ b/src/mnemo_mcp/relay_setup.py
@@ -20,6 +20,7 @@ CLOUD_KEYS = [
     "JINA_AI_API_KEY",
     "GEMINI_API_KEY",
     "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
     "COHERE_API_KEY",
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
@@ -158,6 +159,14 @@ async def _handle_post_config_setup(
 
     apply_config(config)
 
+    from mnemo_mcp.sync import resolve_active_backend
+
+    if resolve_active_backend() != "gdrive":
+        await _send_relay_message(
+            relay_url, session.session_id, "complete", "Setup complete!"
+        )
+        return True
+
     # Notify relay page: config saved (info, NOT complete — GDrive OAuth follows)
     await _send_relay_message(
         relay_url,
@@ -183,6 +192,11 @@ async def _handle_post_config_setup(
 async def _setup_gdrive_sync(relay_url: str, session_id: str) -> bool:
     """Handle Google Drive OAuth setup if a client ID is configured."""
     from mnemo_mcp.config import settings as _settings
+    from mnemo_mcp.sync import resolve_active_backend
+
+    if resolve_active_backend() != "gdrive":
+        logger.info("GDrive setup skipped: not the active sync backend")
+        return True
 
     if not _settings.google_drive_client_id:
         return False

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -143,6 +143,10 @@ async def _init_embedding_backend(
     Running this as a background task lets the MCP server accept connections
     immediately instead of blocking on model download or cloud API validation.
     """
+    if os.environ.get("PUBLIC_URL"):
+        logger.info("Embedding: resolved per subject; skipping process-wide probe")
+        return
+
     from mnemo_mcp.credential_state import CredentialState, get_state
     from mnemo_mcp.embedder import init_backend
 
@@ -215,6 +219,10 @@ async def _init_reranker_backend(mode: str) -> None:
     LOCAL: local-only path.
     CONFIGURED: cloud-only path -- no silent local fallback.
     """
+    if os.environ.get("PUBLIC_URL"):
+        logger.info("Reranking: resolved per subject; skipping process-wide probe")
+        return
+
     from mnemo_mcp.credential_state import CredentialState, get_state
     from mnemo_mcp.reranker import clear_reranker, init_reranker
 
@@ -328,32 +336,23 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
         f"vec={'on' if db.vec_enabled else 'off'})"
     )
 
-    # 4. Resolve sync mode (XOR per deployment) + start backend-specific init.
-    #
-    # Per the 2026-05-14 Test B design: operator picks ONE backend at deploy
-    # time. SYNC_S3_BUCKET set -> S3 (Method 2/3 docker); otherwise -> GDrive
-    # (Method 1 local-relay). See ``docs/passport.md``.
-    if not settings.sync_enabled:
-        logger.info("Sync mode: disabled (legacy Google Drive sync is off)")
+    # D1 + Vectorize is durable already; the same resolver gates setup,
+    # background sync and explicit sync operations.
+    from mnemo_mcp.sync import resolve_active_backend
+
+    sync_mode = resolve_active_backend()
+    if sync_mode != "gdrive":
+        logger.info(f"Sync mode: {sync_mode} — GDrive auto-init skipped")
     else:
-        from mnemo_mcp.sync import resolve_active_backend
+        logger.info("Sync mode: gdrive (GDrive user OAuth via relay)")
+        if settings.google_drive_client_id:
+            from mnemo_mcp.sync import start_auto_sync
 
-        sync_mode = resolve_active_backend()
-        if sync_mode == "s3":
-            logger.info("Sync mode: s3 (S3 operator-config) — GDrive auto-init skipped")
-        else:
-            logger.info("Sync mode: gdrive (GDrive user OAuth via relay)")
-            # Legacy GDrive DB-file copy path (Phase 1) — kept for backward
-            # compat with existing GDrive users. Phase 2 passport bundles still
-            # flow through the scheduler regardless of this background task.
-            if settings.google_drive_client_id:
-                from mnemo_mcp.sync import start_auto_sync
-
-                start_auto_sync(db)
-                logger.info(
-                    f"Sync: Google Drive/{settings.sync_folder} "
-                    f"(interval={settings.sync_interval}s)"
-                )
+            start_auto_sync(db)
+            logger.info(
+                f"Sync: Google Drive/{settings.sync_folder} "
+                f"(interval={settings.sync_interval}s)"
+            )
 
     # Shared context -- embedding_model starts as None (not ready yet).
     # Background task updates it in-place once the backend is validated.
@@ -420,7 +419,7 @@ def _get_ctx(ctx: Context | None) -> tuple[MemoryDB, str | None, int]:
                 "JWT sub is required for Cloudflare D1 requests; refusing an "
                 "unscoped backend."
             )
-        request_model = model_for_task("embedding") or lc.get("embedding_model")
+        request_model = model_for_task("embedding")
         db = db.clone_for_sub(sub, embedding_model=request_model)
     return db, lc["embedding_model"], lc["embedding_dims"]
 
@@ -1121,7 +1120,9 @@ async def _handle_stats(ctx: Context | None) -> dict[str, typing.Any]:
     s = await asyncio.to_thread(db.stats)
     s["embedding_model"] = embedding_model
     s["embedding_dims"] = embedding_dims
-    s["sync_enabled"] = settings.sync_enabled
+    from mnemo_mcp.sync import resolve_active_backend
+
+    s["sync_enabled"] = resolve_active_backend() != "disabled"
     s["sync_folder"] = settings.sync_folder
     return s
 
@@ -1456,8 +1457,7 @@ async def _handle_consolidate(
     db, _, _ = _get_ctx(ctx)
     from mnemo_mcp.graph import _has_llm_provider
 
-    mode = settings.resolve_provider_mode()
-    if mode == "local" and not _has_llm_provider():
+    if not _has_llm_provider():
         return {
             "error": "Consolidation requires LLM (SDK mode with API keys)",
             "suggestion": "Run the setup flow or provide API keys via environment variables (e.g. GEMINI_API_KEY).",
@@ -2179,6 +2179,9 @@ async def _handle_config_backfill(
 
 
 async def _handle_config_status(ctx: Context | None) -> dict[str, typing.Any]:
+    from mnemo_mcp.sync import resolve_active_backend
+
+    sync_backend = resolve_active_backend()
     db, embedding_model, embedding_dims = _get_ctx(ctx)
     embedding_model, _ = _get_request_embedding(ctx, embedding_model, embedding_dims)
     s = await asyncio.to_thread(db.stats)
@@ -2199,8 +2202,8 @@ async def _handle_config_status(ctx: Context | None) -> dict[str, typing.Any]:
             "available": embedding_model is not None,
         },
         "sync": {
-            "enabled": settings.sync_enabled,
-            "provider": "google_drive",
+            "enabled": sync_backend != "disabled",
+            "provider": "google_drive" if sync_backend == "gdrive" else sync_backend,
             "folder": settings.sync_folder,
             "interval": settings.sync_interval,
         },
@@ -2468,14 +2471,7 @@ def _resolve_sync_passphrase() -> str | None:
 
 
 def _resolve_default_backend() -> str:
-    """Return the active sync backend per the deployment-mode XOR.
-
-    Delegates to :func:`mnemo_mcp.sync.resolve_active_backend` which checks
-    ``SYNC_S3_BUCKET`` (env > pydantic field). The legacy
-    ``settings.sync_backend`` comma-separated multi-backend value is
-    ignored — operator picks ONE backend at deploy time (Method 1 GDrive
-    via relay vs Method 2/3 S3 via docker env). See ``docs/passport.md``.
-    """
+    """Return the deployment's active sync backend, including ``disabled``."""
     from mnemo_mcp.sync import resolve_active_backend
 
     return resolve_active_backend()
@@ -2485,6 +2481,8 @@ async def _handle_config_sync_now(
     ctx: Context | None, backend: str | None
 ) -> dict[str, typing.Any]:
     """``config(action="sync_now")`` - delta push (or full-pull-push on gap)."""
+    if _resolve_default_backend() == "disabled":
+        return {"status": "disabled", "message": "External sync is disabled"}
     db, _, _ = _get_ctx(ctx)
     passphrase = _resolve_sync_passphrase()
     if not passphrase:
@@ -2547,6 +2545,8 @@ async def _handle_config_import_passport(
     ctx: Context | None, source: str | None
 ) -> dict[str, typing.Any]:
     """``config(action="import_passport", from="s3"|"gdrive")``."""
+    if _resolve_default_backend() == "disabled":
+        return {"status": "disabled", "message": "External sync is disabled"}
     db, _, _ = _get_ctx(ctx)
     passphrase = _resolve_sync_passphrase()
     if not passphrase:

--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -114,6 +114,44 @@ async def run_warmup() -> dict:
         "steps": [{"step": str, "status": str, ...}, ...],
     }
     """
+    from mnemo_mcp.credential_state import (
+        api_base_for_task,
+        api_key_for_model,
+        get_current_sub,
+        model_for_task,
+    )
+
+    if get_current_sub() is not None:
+        from mnemo_mcp.embedder import CloudEmbeddingBackend
+
+        model = model_for_task("embedding")
+        key = api_key_for_model(model) if model else None
+        if not model or not key:
+            return {"status": "ok", "mode": "unavailable", "steps": []}
+        backend = CloudEmbeddingBackend(
+            model, api_key=key, api_base=api_base_for_task("EMBEDDING_API_BASE")
+        )
+        dims = await asyncio.to_thread(backend.check_available)
+        if dims <= 0:
+            return {
+                "status": "error",
+                "mode": "unavailable",
+                "steps": [{"step": "cloud_embedding", "status": "error"}],
+            }
+        return {
+            "status": "ok",
+            "mode": "cloud",
+            "steps": [
+                {
+                    "step": "cloud_embedding",
+                    "status": "ok",
+                    "model": model,
+                    "dims": dims,
+                }
+            ],
+            "embedding": {"model": model, "dims": dims},
+        }
+
     steps = []
     local_disabled = getattr(settings, "disable_local_embed", False) is True
 
@@ -191,8 +229,15 @@ async def run_setup_sync(
 
     Returns a structured dict with setup results.
     """
-    from mnemo_mcp.sync import setup_google_auth
+    from mnemo_mcp.sync import resolve_active_backend, setup_google_auth
     from mnemo_mcp.token_store import get_token_path
+
+    if resolve_active_backend() != "gdrive":
+        return {
+            "status": "disabled",
+            "provider": "google_drive",
+            "message": "Google Drive sync is not active for this deployment.",
+        }
 
     effective_id = client_id or settings.google_drive_client_id
     if not effective_id:

--- a/src/mnemo_mcp/sync/__init__.py
+++ b/src/mnemo_mcp/sync/__init__.py
@@ -113,17 +113,18 @@ def resolve_active_backend() -> str:
     """
     import os
 
-    settings = globals()["settings"]
+    settings = _gdrive_module.settings
+    configured_bucket = settings.sync_s3_bucket
+    bucket_from_settings = (
+        configured_bucket.strip() if isinstance(configured_bucket, str) else ""
+    )
 
     if (
         os.environ.get("MEMORY_DB_BACKEND", "").strip().lower() == "cf-d1"
         or not settings.sync_enabled
     ):
         return "disabled"
-    if (
-        os.environ.get("SYNC_S3_BUCKET", "").strip()
-        or (settings.sync_s3_bucket or "").strip()
-    ):
+    if os.environ.get("SYNC_S3_BUCKET", "").strip() or bucket_from_settings:
         return "s3"
     return "gdrive"
 

--- a/src/mnemo_mcp/sync/__init__.py
+++ b/src/mnemo_mcp/sync/__init__.py
@@ -104,34 +104,27 @@ def register(name: str, backend: SyncBackend) -> None:
 
 
 def resolve_active_backend() -> str:
-    """Return the active sync backend (``"s3"`` or ``"gdrive"``) per deployment.
+    """Resolve ``disabled``, ``s3`` or ``gdrive`` for this deployment.
 
-    XOR selection per the 2026-05-14 Test B clarification:
-
-    * **S3** when ``SYNC_S3_BUCKET`` is set via env var OR via the pydantic
-      ``settings.sync_s3_bucket`` field. Indicates Method 2/3 (HTTP / Docker
-      deploy) where the operator wires S3 credentials at container spawn.
-    * **GDrive** otherwise. Indicates Method 1 (local-relay / uvx) where
-      end-users authorise their Google account via the relay form.
-
-    Pure function — no side effects, safe to call from lifespan startup,
-    scheduler loop, MCP tool handlers, anywhere. The env var takes
-    precedence over the pydantic field so an operator can override a
-    persisted setting without rewriting ``config.enc``.
+    Cloudflare D1 + Vectorize is already durable, so external sync is disabled
+    even when stale bucket/client settings remain. ``SYNC_ENABLED=false`` is
+    also a hard off switch. Otherwise S3 bucket configuration takes precedence
+    over the local Google Drive OAuth flow.
     """
-    import os as _os
+    import os
 
-    if _os.environ.get("SYNC_S3_BUCKET", "").strip():
+    from mnemo_mcp.config import settings
+
+    if (
+        os.environ.get("MEMORY_DB_BACKEND", "").strip().lower() == "cf-d1"
+        or not settings.sync_enabled
+    ):
+        return "disabled"
+    if (
+        os.environ.get("SYNC_S3_BUCKET", "").strip()
+        or (settings.sync_s3_bucket or "").strip()
+    ):
         return "s3"
-    try:
-        from mnemo_mcp.config import settings as _settings
-
-        if (_settings.sync_s3_bucket or "").strip():
-            return "s3"
-    except Exception:
-        # Settings import / instantiation failure is non-fatal — fall
-        # through to the gdrive default so the server still starts.
-        pass
     return "gdrive"
 
 
@@ -150,8 +143,11 @@ def get(name: str) -> SyncBackend:
       sees a helpful "configure SYNC_S3_BUCKET" message instead of a
       cryptic boto3 NoCredentialsError later).
     """
+    active = resolve_active_backend()
+    if active == "disabled":
+        raise KeyError("External sync is disabled for this deployment")
     if name == "auto":
-        name = resolve_active_backend()
+        name = active
     if name == "gdrive" and "gdrive" not in _REGISTRY:
         _REGISTRY["gdrive"] = GDriveBackend()
     if name == "s3" and "s3" not in _REGISTRY:
@@ -237,6 +233,9 @@ async def _passport_sync_loop(db, interval: int) -> None:
             continue
 
         backend_name = resolve_active_backend()
+        if backend_name == "disabled":
+            logger.info("Passport sync scheduler stopped: external sync disabled")
+            return
 
         async with _PASSPORT_SYNC_LOCK:
             try:
@@ -254,6 +253,9 @@ def start_passport_scheduler(db, interval: int | None = None) -> bool:
     """
     global _PASSPORT_SYNC_TASK
     from mnemo_mcp.config import settings as _settings
+
+    if resolve_active_backend() == "disabled":
+        return False
 
     if interval is None:
         interval = int(_settings.sync_interval or 0)

--- a/src/mnemo_mcp/sync/__init__.py
+++ b/src/mnemo_mcp/sync/__init__.py
@@ -113,7 +113,7 @@ def resolve_active_backend() -> str:
     """
     import os
 
-    from mnemo_mcp.config import settings
+    settings = globals()["settings"]
 
     if (
         os.environ.get("MEMORY_DB_BACKEND", "").strip().lower() == "cf-d1"

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -576,9 +576,10 @@ async def sync_full(db: MemoryDB) -> dict:
         Dict with sync results.
     """
     from mnemo_mcp.db import MemoryDB
+    from mnemo_mcp.sync import resolve_active_backend
 
-    if not settings.sync_enabled:
-        return {"status": "disabled", "message": "Sync is disabled"}
+    if resolve_active_backend() != "gdrive":
+        return {"status": "disabled", "message": "Google Drive sync is not active"}
 
     if not settings.google_drive_client_id:
         return {
@@ -797,6 +798,12 @@ async def setup_google_auth(
 
     Returns True on success, False on failure.
     """
+    from mnemo_mcp.sync import resolve_active_backend
+
+    if resolve_active_backend() != "gdrive":
+        logger.info("Google Drive OAuth skipped: not the active sync backend")
+        return False
+
     client_id = client_id or settings.google_drive_client_id
     client_secret = client_secret or settings.google_drive_client_secret
     if not client_id or not client_secret:
@@ -859,8 +866,9 @@ async def _auto_sync_loop(db: MemoryDB) -> None:
 def start_auto_sync(db: MemoryDB) -> None:
     """Start background auto-sync task."""
     global _sync_task
+    from mnemo_mcp.sync import resolve_active_backend
 
-    if not settings.sync_enabled:
+    if resolve_active_backend() != "gdrive":
         return
 
     if not settings.google_drive_client_id or settings.sync_interval <= 0:
@@ -892,6 +900,12 @@ def setup_sync() -> None:
     Runs Device Code OAuth flow, saves token locally.
     """
     import sys
+
+    from mnemo_mcp.sync import resolve_active_backend
+
+    if resolve_active_backend() != "gdrive":
+        print("Google Drive sync is disabled for this deployment.")
+        return
 
     print("=== Mnemo MCP: Setup Google Drive Sync ===")
 

--- a/src/mnemo_mcp/temporal/extract.py
+++ b/src/mnemo_mcp/temporal/extract.py
@@ -12,9 +12,9 @@ Phase 3 additions:
   ``{old_fact_id, confidence}`` objects (consumed by
   :mod:`mnemo_mcp.temporal.supersede`). Old callers that ignore the field
   see no behavioural change.
-* Dispatch flows through :func:`mnemo_mcp.llm.call_llm` so the auto-
-  detected provider (Gemini > OpenAI > Anthropic > xAI) is honoured
-  uniformly with the rest of Phase 1 / Phase 2.
+* Dispatch flows through :func:`mnemo_mcp.llm.call_llm`: authenticated subjects
+  use their own relay model, endpoint and key; local single-user calls retain
+  environment-based provider detection.
 """
 
 from __future__ import annotations

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,17 +39,12 @@ export interface Env {
   MCP_D1_BASE_URL: string
   MCP_VECTORIZE_BASE_URL: string
   MCP_VECTORIZE_IDX: string
-  EMBEDDING_MODELS: string
-  RERANK_MODELS: string
-  LLM_MODELS: string
   EMBEDDING_DIMS: string
   REINDEX_ON_MODEL_CHANGE: string
+  SYNC_ENABLED: string
   RECENCY_HALF_LIFE_DAYS: string
   PUBLIC_URL: string
   CREDENTIAL_SECRET: string
-  JINA_AI_API_KEY: string
-  GEMINI_API_KEY: string
-  GOOGLE_VERTEX_EXPRESS_API_KEY: string
   MCP_RELAY_PASSWORD: string
   MCP_DCR_SERVER_SECRET: string
 }
@@ -61,11 +56,8 @@ export interface Env {
 // container falls back to a default with no error. tests/worker.test.ts asserts
 // this coverage against all three wrangler files (wrangler.jsonc,
 // wrangler.deploy.jsonc, wrangler.deploy.template.jsonc), so it fails loudly
-// instead. The other 11 keys below are NOT declared as `vars` anywhere and are
-// loaded with `wrangler secret put`: RECENCY_HALF_LIFE_DAYS, CREDENTIAL_SECRET,
-// JINA_AI_API_KEY, GEMINI_API_KEY, GOOGLE_VERTEX_EXPRESS_API_KEY,
-// MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET, OPENROUTER_API_BASE,
-// OPENROUTER_API_KEY, JINA_AI_API_BASE, REINDEX_ON_MODEL_CHANGE.
+// instead. Provider model, endpoint and key values are deliberately excluded:
+// authenticated subjects resolve them from their encrypted relay store.
 // MCP_RELAY_PASSWORD MUST stay here: the
 // container's OAuth-AS browser form (Gate A) is gated by it -- dropping it would
 // open the relay form to anyone. CREDENTIAL_SECRET + MCP_DCR_SERVER_SECRET
@@ -73,16 +65,12 @@ export interface Env {
 export const CONTAINER_ENV_KEYS = [
   'MCP_STORAGE_BACKEND', 'MCP_KV_BASE_URL', 'MEMORY_DB_BACKEND',
   'MCP_D1_BASE_URL', 'MCP_VECTORIZE_BASE_URL', 'MCP_VECTORIZE_IDX',
-  'EMBEDDING_MODELS', 'RERANK_MODELS', 'LLM_MODELS',
   'EMBEDDING_DIMS', 'REINDEX_ON_MODEL_CHANGE', 'RECENCY_HALF_LIFE_DAYS',
     // Cloudflare is the post-cutover store; never start the legacy GDrive
     // background sync task in the container.
     'SYNC_ENABLED',
   'PUBLIC_URL', 'CREDENTIAL_SECRET',
-  'JINA_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_VERTEX_EXPRESS_API_KEY',
   'MCP_RELAY_PASSWORD', 'MCP_DCR_SERVER_SECRET',
-  // CF AI Gateway (llm-main) litellm routing
-  'OPENROUTER_API_BASE', 'OPENROUTER_API_KEY', 'JINA_AI_API_BASE',
 ] as const
 
 function pickContainerEnv(env: Env): Record<string, string> {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,6 +199,10 @@ def _clear_provider_environment(monkeypatch):
         "EMBEDDING_MODELS",
         "RERANK_MODELS",
         "LLM_MODELS",
+        "MEMORY_DB_BACKEND",
+        "SYNC_ENABLED",
+        "SYNC_S3_BUCKET",
+        "PUBLIC_URL",
         "OPENAI_API_KEY",
         "OPENAI_API_BASE",
         "OPENROUTER_API_KEY",
@@ -215,6 +219,11 @@ def _clear_provider_environment(monkeypatch):
         "GEMINI_API_BASE",
     ):
         monkeypatch.delenv(key, raising=False)
+
+    from mnemo_mcp.config import settings
+
+    settings.sync_enabled = True
+    settings.sync_s3_bucket = ""
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,32 @@ def _isolate_per_plugin_home(tmp_path_factory, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _clear_provider_environment(monkeypatch):
+    """Keep unit tests independent of workstation and CI provider secrets."""
+    for key in (
+        "API_KEYS",
+        "EMBEDDING_MODELS",
+        "RERANK_MODELS",
+        "LLM_MODELS",
+        "OPENAI_API_KEY",
+        "OPENAI_API_BASE",
+        "OPENROUTER_API_KEY",
+        "OPENROUTER_API_BASE",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_API_BASE",
+        "XAI_API_KEY",
+        "XAI_API_BASE",
+        "JINA_AI_API_KEY",
+        "JINA_AI_API_BASE",
+        "COHERE_API_KEY",
+        "COHERE_API_BASE",
+        "GEMINI_API_KEY",
+        "GEMINI_API_BASE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _set_credential_state_configured():
     """Set credential state to CONFIGURED for all tests.
 

--- a/tests/sync/test_gdrive.py
+++ b/tests/sync/test_gdrive.py
@@ -783,14 +783,6 @@ def test_start_auto_sync_already_running():
             # Should return without creating new task (already running)
 
 
-def test_start_auto_sync_disabled():
-    mock_db = MagicMock()
-    with patch("mnemo_mcp.sync.gdrive.settings") as mock_settings:
-        mock_settings.sync_enabled = False
-        start_auto_sync(mock_db)
-        # Should return immediately
-
-
 def test_start_auto_sync_missing_config():
     mock_db = MagicMock()
     with patch("mnemo_mcp.sync.gdrive.settings") as mock_settings:

--- a/tests/sync/test_sync_backend_resolve.py
+++ b/tests/sync/test_sync_backend_resolve.py
@@ -72,9 +72,9 @@ def test_settings_field_alone_returns_s3(monkeypatch: pytest.MonkeyPatch) -> Non
     import mnemo_mcp.config as config_mod
     from mnemo_mcp.config import Settings
 
-    monkeypatch.setattr(
-        config_mod, "settings", Settings(sync_s3_bucket="persisted-bucket")
-    )
+    persisted = Settings(sync_s3_bucket="persisted-bucket")
+    monkeypatch.setattr(config_mod, "settings", persisted)
+    monkeypatch.setattr("mnemo_mcp.sync.gdrive.settings", persisted)
     assert resolve_active_backend() == "s3"
 
 

--- a/tests/sync/test_sync_backend_resolve.py
+++ b/tests/sync/test_sync_backend_resolve.py
@@ -34,8 +34,15 @@ def _isolated_registry() -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ensure SYNC_S3_BUCKET is unset at the start of every test."""
+    """Isolate deployment selection from the runner's environment."""
     monkeypatch.delenv("SYNC_S3_BUCKET", raising=False)
+    monkeypatch.delenv("MEMORY_DB_BACKEND", raising=False)
+    monkeypatch.setenv("SYNC_ENABLED", "true")
+
+    from mnemo_mcp.config import settings
+
+    monkeypatch.setattr(settings, "sync_enabled", True)
+    monkeypatch.setattr(settings, "sync_s3_bucket", "")
 
 
 # ---------------------------------------------------------------------------
@@ -140,3 +147,82 @@ def test_get_auto_dispatches_to_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     backend = sync_pkg.get("auto")
     # S3Backend has name="s3" attribute per the base contract.
     assert backend.name == "s3"
+
+
+async def test_cf_d1_suppresses_google_setup_sync_and_scheduling(monkeypatch):
+    from mnemo_mcp import credential_state, relay_setup, setup_tool
+    from mnemo_mcp.config import settings
+    from mnemo_mcp.server import (
+        _handle_config_import_passport,
+        _handle_config_sync_now,
+    )
+
+    monkeypatch.setenv("MEMORY_DB_BACKEND", " CF-D1 ")
+    monkeypatch.setenv("SYNC_S3_BUCKET", "stale-bucket")
+    monkeypatch.setattr(settings, "google_drive_client_id", "fixture-client")
+    monkeypatch.setattr(settings, "google_drive_client_secret", "fixture-secret")
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("A disabled sync path touched Google or scheduled background work")
+
+    monkeypatch.setattr("httpx.post", forbidden)
+    monkeypatch.setattr(sync_pkg.asyncio, "create_task", forbidden)
+    assert resolve_active_backend() == "disabled"
+    assert credential_state._trigger_gdrive_flow(sub="fixture-sub") is None
+    assert await relay_setup._setup_gdrive_sync("https://relay.example", "fixture")
+    assert await sync_pkg.setup_google_auth() is False
+    assert (await setup_tool.run_setup_sync())["status"] == "disabled"
+    assert (await sync_pkg.sync_full(None))["status"] == "disabled"
+    sync_pkg.start_auto_sync(None)
+    assert sync_pkg.start_passport_scheduler(None) is False
+    assert (await _handle_config_sync_now(None, "gdrive"))["status"] == "disabled"
+    assert (await _handle_config_import_passport(None, "gdrive"))[
+        "status"
+    ] == "disabled"
+    for backend in ("auto", "gdrive", "s3"):
+        with pytest.raises(KeyError):
+            sync_pkg.get(backend)
+
+
+async def test_non_cf_google_setup_remains_available(monkeypatch):
+    from mnemo_mcp import credential_state, relay_setup
+    from mnemo_mcp.config import settings
+
+    monkeypatch.setenv("MEMORY_DB_BACKEND", "sqlite")
+    monkeypatch.setattr(settings, "google_drive_client_id", "fixture-client")
+    monkeypatch.setattr(settings, "google_drive_client_secret", "fixture-secret")
+    requests = []
+
+    def reject_device_code(url, **kwargs):
+        from types import SimpleNamespace
+
+        requests.append(url)
+        return SimpleNamespace(status_code=400)
+
+    async def reject_async_device_code(client_id):
+        requests.append("async-device-code")
+        return None
+
+    monkeypatch.setattr("httpx.post", reject_device_code)
+    monkeypatch.setattr(sync_pkg, "_request_device_code", reject_async_device_code)
+    assert resolve_active_backend() == "gdrive"
+    assert credential_state._trigger_gdrive_flow() is None
+    assert (
+        await relay_setup._setup_gdrive_sync("https://relay.example", "fixture")
+        is False
+    )
+    assert requests == [
+        "https://oauth2.googleapis.com/device/code",
+        "async-device-code",
+    ]
+
+
+def test_disabled_sync_blocks_explicit_backend_and_scheduler(monkeypatch):
+    from mnemo_mcp.config import settings
+
+    monkeypatch.setenv("SYNC_S3_BUCKET", "configured-bucket")
+    monkeypatch.setattr(settings, "sync_enabled", False)
+    assert resolve_active_backend() == "disabled"
+    with pytest.raises(KeyError):
+        sync_pkg.get("s3")
+    assert sync_pkg.start_passport_scheduler(None) is False

--- a/tests/test_cf_full_flow.py
+++ b/tests/test_cf_full_flow.py
@@ -56,31 +56,6 @@ def test_configure_cohere_cf_gateway_uses_existing_gateway_token(monkeypatch):
     assert not os.environ.get("JINA_AI_API_KEY")
 
 
-def test_configure_cohere_direct_uses_direct_alias_and_clears_stale_routes(monkeypatch):
-    for name in (
-        "JINA_AI_API_KEY",
-        "GEMINI_API_KEY",
-        "OPENAI_API_KEY",
-        "XAI_API_KEY",
-        "COHERE_API_KEY",
-        "EMBEDDING_MODELS",
-        "EMBEDDING_API_BASE",
-        "RERANK_MODELS",
-        "RERANK_API_BASE",
-        "LLM_MODELS",
-        "LLM_API_BASE",
-    ):
-        monkeypatch.setenv(name, "stale")
-    monkeypatch.setenv("COHERE_API_KEY_DIRECT", "direct-token")
-
-    _HARNESS._configure_cohere_direct()
-
-    assert os.environ["COHERE_API_KEY"] == "direct-token"
-    assert os.environ["EMBEDDING_MODELS"] == "cohere/embed-multilingual-v3.0"
-    assert os.environ["RERANK_MODELS"] == "cohere/rerank-multilingual-v3.0"
-    assert not os.environ.get("JINA_AI_API_KEY")
-
-
 def test_assert_rerank_payload_requires_semantic_and_reranked_flags():
     payload = {
         "semantic": True,
@@ -332,3 +307,49 @@ async def test_run_two_sub_isolation_uses_distinct_markers_and_exact_cleanup(
     assert "-isolation-b-" in marker_b
     assert marker_a != marker_b
     assert session_b.calls[-1][1]["memory_id"] == "memory-1"
+
+
+@pytest.mark.asyncio
+async def test_tool_receipts_never_print_memory_data_or_provider_error_details(capsys):
+    private_fixture = "fixture-private-memory-detail"
+
+    class Session:
+        async def call_tool(self, name, args):
+            if name == "failure":
+                raise RuntimeError(private_fixture)
+            return SimpleNamespace(
+                content=[SimpleNamespace(text=json.dumps({"content": private_fixture}))]
+            )
+
+    assert await _HARNESS._call(Session(), "FIXTURE", "success", {}) is not None
+    assert await _HARNESS._call(Session(), "FIXTURE", "failure", {}) is None
+    receipt = capsys.readouterr()
+    assert private_fixture not in receipt.out + receipt.err
+
+
+@pytest.mark.asyncio
+async def test_completion_failure_removes_every_exact_provider_fixture():
+    class CompletionFailure(_FakeSession):
+        async def call_tool(self, name, arguments):
+            if name == "search_memory":
+                payload = {
+                    "semantic": True,
+                    "reranked": True,
+                    "results": [{"id": memory_id} for memory_id in self.memories],
+                }
+                return SimpleNamespace(
+                    content=[SimpleNamespace(text=json.dumps(payload))]
+                )
+            if name == "consolidate_memories":
+                return SimpleNamespace(
+                    content=[
+                        SimpleNamespace(text=json.dumps({"error": "fixture failure"}))
+                    ]
+                )
+            return await super().call_tool(name, arguments)
+
+    session = CompletionFailure()
+    with pytest.raises(AssertionError):
+        await _HARNESS._run_rerank(session)
+    assert session.next_id == 3
+    assert session.memories == {}

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -494,25 +494,32 @@ class TestApiBaseCloudKeys:
             == "https://gw-a.example/cohere/v2/embed"
         )
 
-
-class TestApiBaseSSRF:
     async def test_embedder_loopback_api_base_blocked_in_multi_user(self, monkeypatch):
         # Multi-user (PUBLIC_URL set): a per-sub custom endpoint pointing at
         # loopback/private is rejected by the mcp-core SSRF vet before any
-        # network call. mnemo reads os.getenv(EMBEDDING_API_BASE) and passes it
-        # to mcp_core.llm.aembedding, which vets via _prep_api_base -- no local
-        # wrap needed.
+        # network call. Mnemo must resolve the endpoint from the authenticated
+        # subject rather than falling back to process-global environment.
         import pytest
         from mcp_core.http import SSRFBlockedError
 
+        from mnemo_mcp.credential_state import _current_sub
         from mnemo_mcp.embedder import CloudEmbeddingBackend
 
         monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example.com")
-        monkeypatch.setenv("EMBEDDING_API_BASE", "http://127.0.0.1:11434")
+        token = _current_sub.set("test-sub")
+        monkeypatch.setattr(
+            "mnemo_mcp.credential_state.read_for_sub",
+            lambda sub: {
+                "EMBEDDING_API_BASE": "http://127.0.0.1:11434",
+            },
+        )
         # Stub the lazy litellm accessor so the test exercises the real vet in
         # dispatch._prep_api_base without the multi-second litellm cold import.
         # The vet runs before the (mocked) network leg, so the block still fires.
         monkeypatch.setattr("mcp_core.llm.dispatch._get_litellm", MagicMock())
         backend = CloudEmbeddingBackend("cohere/embed-multilingual-v3.0")
-        with pytest.raises(SSRFBlockedError):
-            await backend._call_provider(["hello"])
+        try:
+            with pytest.raises(SSRFBlockedError):
+                await backend._call_provider(["hello"])
+        finally:
+            _current_sub.reset(token)

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -135,6 +135,7 @@ async def test_lifespan_happy_path_cloud(
 @pytest.mark.asyncio
 async def test_lifespan_sync_enabled(mock_settings, mock_db, mock_embedder, mock_sync):
     """Test auto-sync startup."""
+    mock_settings.google_drive_client_id = "client123"
     mock_settings.sync_enabled = True
     mock_settings.sync_folder = "folder"
     mock_settings.sync_interval = 60

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -41,6 +41,7 @@ def mock_settings():
         m.resolve_embedding_dims.return_value = 0
         m.resolve_embedding_backend.return_value = "cloud"
         m.sync_enabled = False
+        m.google_drive_client_id = ""
         m.get_db_path.return_value = "test.db"
         m.resolve_local_embedding_model.return_value = "local-model"
         yield m

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -131,15 +131,12 @@ def test_call_llm_graceful_skip_no_provider() -> None:
 
 
 def test_call_llm_unknown_explicit_provider_returns_none() -> None:
-    """Explicit but unsupported provider returns None when litellm raises."""
-    mock = AsyncMock(side_effect=Exception("bogus provider"))
-    with (
-        patch("mcp_core.llm.acompletion", mock),
-        patch.object(llm.logger, "warning") as warn,
-    ):
+    """Unsupported explicit providers return None without dispatching a request."""
+    mock = AsyncMock()
+    with patch("mcp_core.llm.acompletion", mock):
         result = asyncio.run(llm.call_llm("hello", provider="bogus"))
     assert result is None
-    assert warn.called
+    mock.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_per_sub_model_config.py
+++ b/tests/test_per_sub_model_config.py
@@ -20,13 +20,14 @@ from mnemo_mcp.credential_state import (
 from mnemo_mcp.embedder import CloudEmbeddingBackend
 from mnemo_mcp.graph import _has_llm_provider, _llm_completion, _resolve_llm_model
 from mnemo_mcp.llm import call_llm
-from mnemo_mcp.relay_schema import RELAY_SCHEMA
 from mnemo_mcp.reranker import CloudReranker
 
 
 @pytest.fixture(autouse=True)
-def _reset_current_sub():
+def _reset_current_sub(monkeypatch):
     token = _current_sub.set(None)
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     try:
         yield
     finally:
@@ -313,12 +314,120 @@ async def test_graph_uses_current_sub_model_key_and_endpoint(monkeypatch, tmp_pa
     assert captured["api_base"] == "https://alice.example/llm"
 
 
-def test_relay_schema_exposes_per_task_endpoints_and_vertex_key():
-    fields = {field["key"]: field for field in RELAY_SCHEMA["fields"]}
+async def test_minimax_subject_beats_ambient_and_unrelated_provider_keys(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "tiktoken.get_encoding",
+        lambda _name: SimpleNamespace(encode=lambda text: text.split()),
+    )
+    from mnemo_mcp.compression import compress
+    from mnemo_mcp.graph import score_importance
+    from mnemo_mcp.llm import detect_provider
 
-    for key in ("EMBEDDING_API_BASE", "RERANK_API_BASE", "LLM_API_BASE"):
-        assert fields[key]["type"] == "url"
-        assert fields[key]["required"] is False
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("COMPRESSION_PROVIDER", "openai")
+    monkeypatch.setenv("COMPRESSION_MODEL", "ambient-paid-model")
+    monkeypatch.setenv("LLM_MODELS", "openai/ambient-paid-model")
+    monkeypatch.setenv("LLM_API_BASE", "https://ambient.example/v1")
+    store_for_sub(
+        "alice",
+        {
+            "LLM_MODELS": "openrouter/minimax/minimax-m3:free",
+            "LLM_API_BASE": "https://alice.example/openrouter/v1",
+            "OPENROUTER_API_KEY": "fixture-openrouter",
+            "GEMINI_API_KEY": "unrelated-fixture",
+        },
+    )
+    _current_sub.set("alice")
 
-    assert fields["GOOGLE_VERTEX_EXPRESS_API_KEY"]["type"] == "password"
-    assert fields["GOOGLE_VERTEX_EXPRESS_API_KEY"]["derived"] is True
+    async def subject_completion(**kwargs):
+        assert kwargs["model"] == "openrouter/minimax/minimax-m3:free"
+        assert kwargs["api_base"] == "https://alice.example/openrouter/v1"
+        assert kwargs["api_key"] == "fixture-openrouter"
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="0.8"))]
+        )
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", subject_completion)
+    assert detect_provider() == "openrouter"
+    assert await score_importance("A fixture preference") == 0.8
+    result = await compress("A long fixture preference with redundant repeated words.")
+    assert result["compressed"] is True
+    assert result["compression_provider"] == "openrouter"
+    assert result["compression_model"] == "minimax/minimax-m3:free"
+
+
+async def test_empty_subject_completion_does_not_inherit_ambient_provider(
+    monkeypatch, tmp_path
+):
+    from mnemo_mcp.graph import score_importance
+
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("GEMINI_API_KEY", "ambient-fixture")
+    monkeypatch.setenv("LLM_MODELS", "gemini/ambient-paid-model")
+    _current_sub.set("empty-subject")
+
+    async def forbidden(**kwargs):
+        pytest.fail("An empty subject dispatched an ambient provider request")
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", forbidden)
+    assert await call_llm("fixture") is None
+    assert await score_importance("fixture") == 0.5
+
+
+async def test_subject_model_without_key_cannot_use_ambient_credentials(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "ambient-fixture")
+    store_for_sub(
+        "missing-key",
+        {
+            "LLM_MODELS": "openrouter/minimax/minimax-m3:free",
+            "LLM_API_BASE": "https://subject.example/openrouter/v1",
+        },
+    )
+    _current_sub.set("missing-key")
+
+    async def forbidden(**kwargs):
+        pytest.fail("A subject without a provider key reached dispatch")
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", forbidden)
+    assert await call_llm("fixture") is None
+    with pytest.raises(RuntimeError):
+        await _llm_completion("openrouter/minimax/minimax-m3:free", [])
+
+
+def test_remote_missing_subject_and_endpoint_fail_closed(monkeypatch, tmp_path):
+    from mnemo_mcp.credential_state import credentials_for_current_request
+
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example")
+    monkeypatch.setenv("MCP_LLM_GATEWAY_BASE", "https://ambient.example/v1")
+    with pytest.raises(RuntimeError):
+        credentials_for_current_request()
+    _current_sub.set("no-endpoint")
+    with pytest.raises(RuntimeError):
+        api_base_for_task("LLM_API_BASE")
+
+
+@pytest.mark.asyncio
+async def test_remote_warmup_does_not_probe_ambient_or_local_models(
+    tmp_path, monkeypatch
+):
+    from mnemo_mcp.setup_tool import run_warmup
+
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("COHERE_API_KEY", "ambient-must-not-be-used")
+    _current_sub.set("empty-warmup-sub")
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError(
+            "Remote warmup attempted process/global provider resolution"
+        )
+
+    monkeypatch.setattr("mnemo_mcp.setup_tool._validate_cloud_models", forbidden)
+    monkeypatch.setattr("mnemo_mcp.setup_tool._download_local_embedding", forbidden)
+    result = await run_warmup()
+    assert result["mode"] == "unavailable"

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -293,8 +293,23 @@ class TestEnsureConfig:
         self, mock_read, mock_session, mock_poll, mock_save, mock_apply, monkeypatch
     ):
         """Relay success triggers GDrive OAuth when client_id is configured."""
+        import mnemo_mcp.config as config_mod
+        from mnemo_mcp.config import Settings
+
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.delenv("SYNC_S3_BUCKET", raising=False)
+        monkeypatch.setenv("MEMORY_DB_BACKEND", "sqlite")
+        monkeypatch.setenv("SYNC_ENABLED", "true")
+        monkeypatch.setattr(
+            config_mod,
+            "settings",
+            Settings(
+                sync_enabled=True,
+                sync_s3_bucket="",
+                google_drive_client_id="client123",
+            ),
+        )
         mock_read.return_value = None
         mock_session.return_value = MagicMock(
             relay_url="https://relay.example.com/#k=abc",
@@ -305,7 +320,6 @@ class TestEnsureConfig:
 
         with (
             patch("httpx.AsyncClient") as mock_httpx,
-            patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
                 "mnemo_mcp.sync.setup_google_auth",
                 new_callable=AsyncMock,
@@ -315,12 +329,13 @@ class TestEnsureConfig:
             mock_client = AsyncMock()
             mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_settings.google_drive_client_id = "client123"
 
             result = await ensure_config()
 
         assert result == config
-        mock_gdrive.assert_called_once_with(
+        mock_save.assert_called_once_with(config)
+        mock_apply.assert_called_once_with(config)
+        mock_gdrive.assert_awaited_once_with(
             relay_url="https://relay.example.com",
             session_id="sess-123",
         )
@@ -334,8 +349,23 @@ class TestEnsureConfig:
         self, mock_read, mock_session, mock_poll, mock_save, mock_apply, monkeypatch
     ):
         """GDrive OAuth failure doesn't prevent config return."""
+        import mnemo_mcp.config as config_mod
+        from mnemo_mcp.config import Settings
+
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.delenv("SYNC_S3_BUCKET", raising=False)
+        monkeypatch.setenv("MEMORY_DB_BACKEND", "sqlite")
+        monkeypatch.setenv("SYNC_ENABLED", "true")
+        monkeypatch.setattr(
+            config_mod,
+            "settings",
+            Settings(
+                sync_enabled=True,
+                sync_s3_bucket="",
+                google_drive_client_id="client123",
+            ),
+        )
         mock_read.return_value = None
         mock_session.return_value = MagicMock(
             relay_url="https://relay.example.com/#k=abc",
@@ -346,21 +376,23 @@ class TestEnsureConfig:
 
         with (
             patch("httpx.AsyncClient") as mock_httpx,
-            patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
                 "mnemo_mcp.sync.setup_google_auth",
                 new_callable=AsyncMock,
                 side_effect=Exception("GDrive OAuth failed"),
-            ),
+            ) as mock_gdrive,
         ):
             mock_client = AsyncMock()
             mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_settings.google_drive_client_id = "client123"
 
             result = await ensure_config()
 
         assert result == config
+        mock_gdrive.assert_awaited_once_with(
+            relay_url="https://relay.example.com",
+            session_id="sess-456",
+        )
 
     @patch("mcp_core.relay.client.create_session", new_callable=AsyncMock)
     @patch("mcp_core.storage.per_plugin_store.PerPluginStore.load")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -700,7 +700,10 @@ class TestConsolidate:
     async def test_consolidate_no_category_non_local(self, ctx_with_db):
         """Cover line 637-638: no category error when mode is not local."""
         ctx, db = ctx_with_db
-        with patch("mnemo_mcp.server.settings") as mock_settings:
+        with (
+            patch("mnemo_mcp.server.settings") as mock_settings,
+            patch("mnemo_mcp.graph._has_llm_provider", return_value=True),
+        ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
             result = await _handle_consolidate(ctx, None)
         assert "error" in result
@@ -711,7 +714,10 @@ class TestConsolidate:
         """Cover lines 640-644: less than 2 memories in category."""
         ctx, db = ctx_with_db
         db.add("only one", category="tech")
-        with patch("mnemo_mcp.server.settings") as mock_settings:
+        with (
+            patch("mnemo_mcp.server.settings") as mock_settings,
+            patch("mnemo_mcp.graph._has_llm_provider", return_value=True),
+        ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
             result = await _handle_consolidate(ctx, "tech")
         assert "error" in result
@@ -725,6 +731,7 @@ class TestConsolidate:
 
         with (
             patch("mnemo_mcp.server.settings") as mock_settings,
+            patch("mnemo_mcp.graph._has_llm_provider", return_value=True),
             patch(
                 "mnemo_mcp.graph._llm_completion",
                 new_callable=AsyncMock,
@@ -747,6 +754,7 @@ class TestConsolidate:
         db.add("mem2", category="tech")
         with (
             patch("mnemo_mcp.server.settings") as mock_settings,
+            patch("mnemo_mcp.graph._has_llm_provider", return_value=True),
             patch(
                 "mnemo_mcp.graph._llm_completion",
                 new_callable=AsyncMock,

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -50,6 +50,36 @@ def ctx_with_db(tmp_path: Path) -> Generator[tuple[MagicMock, MemoryDB]]:
     db.close()
 
 
+@pytest.mark.parametrize("operation", ["add", "update", "capture"])
+async def test_sentinel_validation_errors_hide_internal_details(
+    operation, ctx_with_db, monkeypatch
+):
+    from mnemo_mcp import server
+
+    ctx, db = ctx_with_db
+    internal_detail = "fixture internal storage constraint"
+
+    def reject(*args, **kwargs):
+        raise ValueError(internal_detail)
+
+    if operation == "add":
+        monkeypatch.setattr(db, "add", reject)
+        result = await server._handle_add(ctx, "fixture memory")
+    elif operation == "update":
+        monkeypatch.setattr(db, "update", reject)
+        result = await server._handle_update(ctx, "fixture-id", "fixture memory")
+    else:
+
+        async def reject_capture(*args, **kwargs):
+            raise ValueError(internal_detail)
+
+        monkeypatch.setattr("mnemo_mcp.capture.capture", reject_capture)
+        result = await server._handle_capture(ctx, "fixture memory")
+
+    assert "error" in result
+    assert internal_detail not in json.dumps(result)
+
+
 # ---------------------------------------------------------------------------
 # _embed edge cases
 # ---------------------------------------------------------------------------
@@ -565,112 +595,23 @@ class TestCustomEmbeddingRegistration:
         mock_spec.return_value.register.assert_called_once_with()
 
 
-# ---------------------------------------------------------------------------
-# _init_reranker_backend -- exception paths
-# ---------------------------------------------------------------------------
+async def test_remote_startup_does_not_probe_process_providers_or_local_models(
+    monkeypatch,
+):
+    from mnemo_mcp.server import _init_embedding_backend, _init_reranker_backend
 
+    monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example")
+    monkeypatch.setenv("COHERE_API_KEY", "ambient-must-not-be-used")
 
-class TestInitRerankerBackend:
-    @patch("mnemo_mcp.server.settings")
-    async def test_reranker_unavailable_is_reported(self, mock_settings):
-        """An explicitly unavailable reranker stays disabled without init work."""
-        from mnemo_mcp.server import _init_reranker_backend
+    def forbidden(*args, **kwargs):
+        pytest.fail("Remote startup initialized a process-wide provider/model")
 
-        mock_settings.resolve_rerank_backend.return_value = "unavailable"
-
-        with patch("mnemo_mcp.server.logger") as mock_logger:
-            await _init_reranker_backend("sdk")
-
-        mock_logger.info.assert_called_once_with(
-            "Reranker: unavailable (DISABLE_LOCAL_RERANK set + no cloud model configured)"
-        )
-
-    @patch(
-        "mnemo_mcp.server.asyncio.to_thread",
-        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
-    )
-    @patch("mnemo_mcp.reranker.init_reranker")
-    @patch("mnemo_mcp.server.settings")
-    async def test_local_reranker_init_fails(
-        self, mock_settings, mock_init, _mock_thread
-    ):
-        """When local reranker init raises exception, logs error."""
-        from mnemo_mcp.server import _init_reranker_backend
-
-        mock_settings.resolve_rerank_backend.return_value = "local"
-        mock_settings.resolve_local_rerank_model.return_value = "local/r"
-
-        mock_init.side_effect = Exception("reranker init failed test error")
-
-        with patch("mnemo_mcp.server.logger") as mock_logger:
-            await _init_reranker_backend("local")
-            mock_logger.error.assert_called_with(
-                "Local reranker init failed: reranker init failed test error"
-            )
-
-    @patch(
-        "mnemo_mcp.server.asyncio.to_thread",
-        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
-    )
-    @patch("mnemo_mcp.reranker.init_reranker")
-    @patch("mnemo_mcp.server.settings")
-    async def test_local_reranker_not_available(
-        self, mock_settings, mock_init, _mock_thread
-    ):
-        """When local reranker check_available returns False, logs error."""
-        from mnemo_mcp.server import _init_reranker_backend
-
-        mock_settings.resolve_rerank_backend.return_value = "local"
-        mock_settings.resolve_local_rerank_model.return_value = "local/r"
-
-        mock_backend = MagicMock()
-        mock_backend.check_available.return_value = False
-        mock_init.return_value = mock_backend
-
-        with patch("mnemo_mcp.server.logger") as mock_logger:
-            await _init_reranker_backend("local")
-            mock_logger.error.assert_called_with("Local reranker not available")
-
-    @patch(
-        "mnemo_mcp.server.asyncio.to_thread",
-        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
-    )
-    @patch("mnemo_mcp.server.settings")
-    async def test_reranker_disabled(self, mock_settings, _mock_thread):
-        """When reranker is disabled, logs debug message."""
-        from mnemo_mcp.server import _init_reranker_backend
-
-        mock_settings.resolve_rerank_backend.return_value = None
-
-        with patch("mnemo_mcp.server.logger") as mock_logger:
-            await _init_reranker_backend("sdk")
-            mock_logger.debug.assert_called_with("Reranking disabled")
-
-    @patch(
-        "mnemo_mcp.server.asyncio.to_thread",
-        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
-    )
-    @patch("mnemo_mcp.reranker.init_reranker")
-    @patch("mnemo_mcp.server.settings")
-    async def test_cloud_reranker_not_available_no_local_fallback(
-        self, mock_settings, mock_init, _mock_thread
-    ):
-        """When cloud reranker is not available, logs error (no local fallback)."""
-        from mnemo_mcp.server import _init_reranker_backend
-
-        mock_settings.resolve_rerank_backend.return_value = "cloud"
-        mock_settings.rerank_chain.return_value = ["cloud-model"]
-
-        mock_init.side_effect = Exception("Cloud failed")
-
-        with patch("mnemo_mcp.server.logger") as mock_logger:
-            await _init_reranker_backend("sdk")
-            mock_logger.warning.assert_called_with(
-                "Reranker cloud-model not available: Cloud failed"
-            )
-            mock_logger.error.assert_called_with(
-                "Cloud reranker not available and local fallback is disabled"
-            )
+    monkeypatch.setattr("mnemo_mcp.embedder.init_backend", forbidden)
+    monkeypatch.setattr("mnemo_mcp.reranker.init_reranker", forbidden)
+    context = {"embedding_model": None, "embedding_dims": 1536}
+    await _init_embedding_backend("local", context)
+    await _init_reranker_backend("local")
+    assert context["embedding_model"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_request_scoped_backends.py
+++ b/tests/test_server_request_scoped_backends.py
@@ -113,6 +113,7 @@ def test_embedding_backend_reuses_cache_for_unchanged_credentials(
         "alice",
         {
             "EMBEDDING_MODELS": "cohere/embed-v4.0",
+            "EMBEDDING_API_BASE": "https://alice.example/embed",
             "COHERE_API_KEY": "stable-key",
         },
     )
@@ -122,6 +123,28 @@ def test_embedding_backend_reuses_cache_for_unchanged_credentials(
     try:
         _, first = _get_request_embedding(ctx, "global-model", 768)
         _, second = _get_request_embedding(ctx, "global-model", 768)
+    finally:
+        _current_sub.reset(token)
+
+    assert second is first
+
+
+def test_reranker_reuses_cache_for_unchanged_credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    store_for_sub(
+        "bob",
+        {
+            "RERANK_MODELS": "cohere/rerank-v4.0-fast",
+            "RERANK_API_BASE": "https://bob.example/rerank",
+            "COHERE_API_KEY": "stable-key",
+        },
+    )
+
+    ctx = _typed_ctx()
+    token = _current_sub.set("bob")
+    try:
+        first = _get_request_reranker(ctx)
+        second = _get_request_reranker(ctx)
     finally:
         _current_sub.reset(token)
 
@@ -178,24 +201,3 @@ def test_reranker_is_unavailable_without_model_or_key(tmp_path, monkeypatch):
         assert _get_request_reranker(_typed_ctx()) is None
     finally:
         _current_sub.reset(no_key_token)
-
-
-def test_reranker_reuses_cache_for_unchanged_credentials(tmp_path, monkeypatch):
-    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
-    store_for_sub(
-        "bob",
-        {
-            "RERANK_MODELS": "cohere/rerank-v4.0-fast",
-            "COHERE_API_KEY": "stable-key",
-        },
-    )
-
-    ctx = _typed_ctx()
-    token = _current_sub.set("bob")
-    try:
-        first = _get_request_reranker(ctx)
-        second = _get_request_reranker(ctx)
-    finally:
-        _current_sub.reset(token)
-
-    assert second is first

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.10.0b1"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/wrangler.deploy.jsonc
+++ b/wrangler.deploy.jsonc
@@ -31,9 +31,8 @@
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "mnemo-memory-vectors-1536",
-    "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
-    "RERANK_MODELS": "jina_ai/jina-reranker-v3",
-    "LLM_MODELS": "vertex_express/gemini-3.5-flash",
+    // Models, endpoints and provider keys belong to the authenticated subject.
+    "SYNC_ENABLED": "false",
     "EMBEDDING_DIMS": "1536"
   },
   "observability": { "enabled": true }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,10 +31,9 @@
   ],
   "vectorize": [{ "binding": "VECTORIZE", "index_name": "mnemo-memory-vectors-1536" }],
   // Non-secret container config (forwarded into the container by MnemoContainer.envVars).
-  // Secrets via `wrangler secret put`: CREDENTIAL_SECRET, JINA_AI_API_KEY,
-  // GOOGLE_VERTEX_EXPRESS_API_KEY, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET.
-  // MCP_RELAY_PASSWORD (Gate A, password-grant login) lives in skret /oci-vm-prod/prod
-  // (infra-shared), NOT /mnemo-mcp/prod -- compose both namespaces at `wrangler secret put`.
+  // Operator secrets: CREDENTIAL_SECRET, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET.
+  // Provider keys, models and API bases are saved per subject through the relay.
+  // Managed Gate A source: skret /mcp-stack/prod; no legacy namespace fallback.
   "vars": {
     "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",


### PR DESCRIPTION
## Summary\n- reconcile handed-off per-subject routing, Cloudflare suppression, relay, model, and enterprise changes\n- repair stale regression tests and add coverage for request-scoped backends\n- preserve Sentinel error sanitization and package verification evidence\n\n## Verification\n- ruff format --check .\n- ruff check .\n- ty check\n- focused regression suites and enterprise suite passed\n- uv build --no-sources\n- non-editable mnemo-mcp==2.10.1 Sentinel regression passed\n\nFull repository pytest remains externally blocked by inherited Cloudflare/OpenRouter provider configuration; no paid call was made.