### PR TITLE
feat: mnemo pilot P0 - domain core + CLI/MCP equivalence gate (TOOL-1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dev = [
 
 [project.scripts]
 mnemo-mcp = "mnemo_mcp.cli:main"
+mnemo-pilot = "mnemo_cli.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/n24q02m/mnemo-mcp"
@@ -97,7 +98,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/mnemo_mcp"]
+packages = ["src/mnemo_mcp", "src/mnemo_core", "src/mnemo_cli"]
 
 [tool.hatch.build.targets.wheel.sources]
 "src" = ""
@@ -110,6 +111,8 @@ include = [
     "src/mnemo_mcp/**/*.mako",
     "src/mnemo_mcp/alembic/README",
     "src/mnemo_mcp/py.typed",
+    "src/mnemo_core/**/*.py",
+    "src/mnemo_cli/**/*.py",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mnemo_cli/__init__.py
+++ b/src/mnemo_cli/__init__.py
@@ -1,0 +1,1 @@
+"""mnemo_cli package (TOOL-1 pilot CLI surface)."""

--- a/src/mnemo_cli/__main__.py
+++ b/src/mnemo_cli/__main__.py
@@ -1,0 +1,79 @@
+"""Thin CLI surface over mnemo_core (TOOL-1, P0).
+
+The CLI only parses arguments and serializes the core's envelope. It never
+implements memory logic itself and never invokes the MCP surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from mnemo_core import operations, results
+from mnemo_mcp.db import MemoryDB
+
+
+def _serialize(envelope: dict) -> str:
+    return json.dumps(envelope, sort_keys=True, ensure_ascii=False)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mnemo-pilot",
+        description="Mnemo pilot CLI (capture/recall/fetch) over the shared domain core",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--db", required=True, help="Path to the SQLite memory DB")
+        p.add_argument("--subject", default=None, help="Explicit subject label")
+
+    p_capture = sub.add_parser("capture", help="Store one memory")
+    add_common(p_capture)
+    p_capture.add_argument("content")
+    p_capture.add_argument("--tags", default="", help="Comma-separated tags")
+    p_capture.add_argument("--category", default="general")
+    p_capture.add_argument("--source", default=None)
+
+    p_recall = sub.add_parser("recall", help="Search a subject's memories")
+    add_common(p_recall)
+    p_recall.add_argument("query")
+    p_recall.add_argument("--k", type=int, default=5)
+
+    p_fetch = sub.add_parser("fetch", help="Fetch one memory by id")
+    add_common(p_fetch)
+    p_fetch.add_argument("memory_id")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Returns the taxonomy-mapped process exit code."""
+    args = _build_parser().parse_args(argv)
+    store = MemoryDB(Path(args.db), embedding_dims=0)
+    try:
+        if args.command == "capture":
+            tags = [t.strip() for t in args.tags.split(",") if t.strip()] or None
+            envelope = operations.capture(
+                store,
+                args.subject,
+                args.content,
+                tags=tags,
+                category=args.category,
+                source=args.source,
+            )
+        elif args.command == "recall":
+            envelope = operations.recall(store, args.subject, args.query, k=args.k)
+        else:
+            envelope = operations.fetch(store, args.subject, args.memory_id)
+    finally:
+        store.close()
+    print(_serialize(envelope))
+    return results.exit_code(envelope)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/mnemo_core/__init__.py
+++ b/src/mnemo_core/__init__.py
@@ -1,0 +1,10 @@
+"""mnemo_core: domain layer for the mnemo pilot (TOOL-1, P0).
+
+Surfaces (mnemo_cli, mnemo_mcp pilot tools) depend on this package;
+this package depends on neither.
+"""
+
+from mnemo_core import results
+from mnemo_core.operations import capture, fetch, recall
+
+__all__ = ["capture", "fetch", "recall", "results"]

--- a/src/mnemo_core/operations.py
+++ b/src/mnemo_core/operations.py
@@ -1,0 +1,95 @@
+"""Domain operations for the mnemo pilot (TOOL-1 / P0).
+
+Rules (spec `2026-09-10-mnemo-pilot-mn1-6-tool1-design.md` section 2):
+
+1. This module NEVER imports a surface module (mnemo_mcp server, mnemo_cli)
+   and NEVER reads ``os.environ`` — subject context arrives explicitly.
+2. Every operation returns the shared envelope from ``mnemo_core.results``;
+   surfaces only parse input and serialize the envelope.
+3. Errors are mapped to the shared taxonomy here, in exactly one place.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from mnemo_core import results
+from mnemo_core.ports import StoragePort
+
+# Mirrors mnemo_mcp.db.MAX_CONTENT_LENGTH (validated at the DB layer too);
+# re-declared here so VALIDATION mapping does not depend on the adapter.
+_MAX_CONTENT_LENGTH = 20_000
+
+
+def capture(
+    store: StoragePort,
+    subject: str | None,
+    content: str,
+    tags: list[str] | None = None,
+    category: str = "general",
+    source: str | None = None,
+) -> dict[str, Any]:
+    """Store one memory for a subject. Returns the capture envelope."""
+    if content is None or not content.strip():
+        return results.err(results.VALIDATION, "content is required")
+    try:
+        memory_id = store.add(
+            content=content,
+            category=category,
+            tags=tags,
+            source=source,
+        )
+    except ValueError as exc:
+        return results.err(results.VALIDATION, str(exc))
+    except sqlite3.Error as exc:
+        return results.err(results.STORAGE, f"capture failed: {exc}")
+    except Exception as exc:  # noqa: BLE001 - taxonomy boundary
+        return results.err(results.INTERNAL, f"unexpected failure: {exc}")
+    return results.ok(
+        {
+            "id": memory_id,
+            "subject": subject,
+            "category": category,
+            "tags": tags or [],
+        }
+    )
+
+
+def recall(
+    store: StoragePort,
+    subject: str | None,
+    query: str,
+    k: int = 5,
+) -> dict[str, Any]:
+    """Search a subject's memories. Returns the recall envelope."""
+    if query is None or not query.strip():
+        return results.err(results.VALIDATION, "query is required")
+    if k < 1:
+        return results.err(results.VALIDATION, "k must be >= 1")
+    try:
+        rows = store.search(query, limit=k)
+    except sqlite3.Error as exc:
+        return results.err(results.STORAGE, f"recall failed: {exc}")
+    except Exception as exc:  # noqa: BLE001 - taxonomy boundary
+        return results.err(results.INTERNAL, f"unexpected failure: {exc}")
+    return results.ok({"subject": subject, "query": query, "matches": rows})
+
+
+def fetch(
+    store: StoragePort,
+    subject: str | None,
+    memory_id: str,
+) -> dict[str, Any]:
+    """Fetch one memory by id. Returns the fetch envelope."""
+    if not memory_id:
+        return results.err(results.VALIDATION, "memory_id is required")
+    try:
+        row = store.get(memory_id)
+    except sqlite3.Error as exc:
+        return results.err(results.STORAGE, f"fetch failed: {exc}")
+    except Exception as exc:  # noqa: BLE001 - taxonomy boundary
+        return results.err(results.INTERNAL, f"unexpected failure: {exc}")
+    if row is None:
+        return results.err(results.NOT_FOUND, f"memory {memory_id!r} not found")
+    return results.ok({"subject": subject, "memory": row})

--- a/src/mnemo_core/ports.py
+++ b/src/mnemo_core/ports.py
@@ -1,0 +1,36 @@
+"""Storage port for the mnemo pilot.
+
+The domain layer depends on this protocol only; the concrete adapter is
+mnemo_mcp's :class:`~mnemo_mcp.db.MemoryDB` (satisfied structurally).
+Surfaces never talk to storage directly — they call operations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class StoragePort(Protocol):
+    """Minimal storage surface the pilot operations need."""
+
+    def add(
+        self,
+        content: str,
+        category: str = "general",
+        tags: list[str] | None = None,
+        source: str | None = None,
+        embedding: list[float] | None = None,
+    ) -> str: ...
+
+    def search(
+        self,
+        query: str,
+        embedding: list[float] | None = None,
+        category: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]: ...
+
+    def get(self, memory_id: str) -> dict[str, Any] | None: ...
+
+    def close(self) -> None: ...

--- a/src/mnemo_core/results.py
+++ b/src/mnemo_core/results.py
@@ -1,0 +1,42 @@
+"""Result envelopes shared by every mnemo pilot surface (CLI, MCP).
+
+Both surfaces serialize these plain dicts identically, which is what the
+P0 equivalence harness asserts: same operation + same args => byte-equal
+envelope regardless of surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Error taxonomy (spec section 2, rule 2). Values are stable wire codes.
+VALIDATION = "VALIDATION"
+NOT_FOUND = "NOT_FOUND"
+AUTH_DENIED = "AUTH_DENIED"
+STORAGE = "STORAGE"
+INTERNAL = "INTERNAL"
+
+_EXIT_CODES: dict[str, int] = {
+    VALIDATION: 2,
+    NOT_FOUND: 3,
+    AUTH_DENIED: 4,
+    STORAGE: 5,
+    INTERNAL: 1,
+}
+
+
+def ok(data: dict[str, Any]) -> dict[str, Any]:
+    """Successful envelope."""
+    return {"ok": True, "data": data}
+
+
+def err(code: str, message: str) -> dict[str, Any]:
+    """Failure envelope with a taxonomy code."""
+    return {"ok": False, "error": {"code": code, "message": message}}
+
+
+def exit_code(envelope: dict[str, Any]) -> int:
+    """CLI exit code mapped from the envelope (0 on success)."""
+    if envelope.get("ok"):
+        return 0
+    return _EXIT_CODES.get(envelope["error"]["code"], 1)

--- a/src/mnemo_mcp/pilot_tools.py
+++ b/src/mnemo_mcp/pilot_tools.py
@@ -1,0 +1,37 @@
+"""Pilot MCP-shaped handlers over mnemo_core (TOOL-1, P0).
+
+These are the functions a FastMCP ``@mcp.tool`` registration will wrap in
+P0.1 (thin: parse the tool-args dict, call the core, return the envelope).
+They exist as plain functions so the equivalence harness can exercise the
+exact MCP call path in-process without a running server. The existing rich
+tools in ``mnemo_mcp.server`` are untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mnemo_core import operations
+from mnemo_mcp.db import MemoryDB
+
+
+def pilot_capture(db: MemoryDB, subject: str | None, args: dict[str, Any]) -> dict:
+    """MCP tool ``pilot_capture``: args dict in, envelope out."""
+    return operations.capture(
+        db,
+        subject,
+        args.get("content", ""),
+        tags=args.get("tags"),
+        category=args.get("category", "general"),
+        source=args.get("source"),
+    )
+
+
+def pilot_recall(db: MemoryDB, subject: str | None, args: dict[str, Any]) -> dict:
+    """MCP tool ``pilot_recall``: args dict in, envelope out."""
+    return operations.recall(db, subject, args.get("query", ""), k=args.get("k", 5))
+
+
+def pilot_fetch(db: MemoryDB, subject: str | None, args: dict[str, Any]) -> dict:
+    """MCP tool ``pilot_fetch``: args dict in, envelope out."""
+    return operations.fetch(db, subject, args.get("memory_id", ""))

--- a/tests/test_mnemo_pilot_core.py
+++ b/tests/test_mnemo_pilot_core.py
@@ -1,0 +1,126 @@
+"""Core operation tests for the mnemo pilot (P0)."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from mnemo_core import operations, results
+from mnemo_mcp.db import MemoryDB
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Generator[MemoryDB]:
+    db = MemoryDB(tmp_path / "pilot.db", embedding_dims=0)
+    yield db
+    db.close()
+
+
+def test_capture_returns_id_and_subject(store: MemoryDB) -> None:
+    env = operations.capture(store, "alice", "deploy checklist", tags=["ops"])
+    assert env["ok"] is True
+    assert env["data"]["id"]
+    assert env["data"]["subject"] == "alice"
+    assert env["data"]["tags"] == ["ops"]
+
+
+def test_capture_empty_content_is_validation(store: MemoryDB) -> None:
+    env = operations.capture(store, "alice", "   ")
+    assert env == {
+        "ok": False,
+        "error": {"code": "VALIDATION", "message": "content is required"},
+    }
+
+
+def test_capture_oversized_content_maps_to_validation(store: MemoryDB) -> None:
+    env = operations.capture(store, "alice", "x" * 20_001)
+    assert env["ok"] is False
+    assert env["error"]["code"] == results.VALIDATION
+
+
+def test_recall_matches_captured_memory(store: MemoryDB) -> None:
+    operations.capture(store, "alice", "mnemo pilot uses sqlite FTS5")
+    env = operations.recall(store, "alice", "FTS5")
+    assert env["ok"] is True
+    assert any("FTS5" in m["content"] for m in env["data"]["matches"])
+
+
+def test_recall_empty_query_is_validation(store: MemoryDB) -> None:
+    env = operations.recall(store, "alice", "  ")
+    assert env["error"]["code"] == results.VALIDATION
+
+
+def test_fetch_missing_id_is_not_found(store: MemoryDB) -> None:
+    env = operations.fetch(store, "alice", "deadbeef")
+    assert env["ok"] is False
+    assert env["error"]["code"] == results.NOT_FOUND
+
+
+def test_fetch_existing_id_round_trips(store: MemoryDB) -> None:
+    captured = operations.capture(store, "alice", "round trip")
+    env = operations.fetch(store, "alice", captured["data"]["id"])
+    assert env["ok"] is True
+    assert env["data"]["memory"]["content"] == "round trip"
+
+
+def test_storage_failure_maps_to_storage_code(
+    store: MemoryDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(*a: object, **kw: object) -> str:
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(store, "add", boom)
+    env = operations.capture(store, "alice", "anything")
+    assert env["ok"] is False
+    assert env["error"]["code"] == results.STORAGE
+
+
+def test_subject_isolation_between_stores(tmp_path: Path) -> None:
+    alice = MemoryDB(tmp_path / "alice.db", embedding_dims=0)
+    bob = MemoryDB(tmp_path / "bob.db", embedding_dims=0)
+    try:
+        operations.capture(alice, "alice", "alice private note")
+        env_bob = operations.recall(bob, "bob", "alice private note")
+        assert env_bob["ok"] is True
+        assert env_bob["data"]["matches"] == []
+    finally:
+        alice.close()
+        bob.close()
+
+
+def test_exit_code_mapping() -> None:
+    assert results.exit_code(results.ok({})) == 0
+    assert results.exit_code(results.err(results.VALIDATION, "m")) == 2
+    assert results.exit_code(results.err(results.NOT_FOUND, "m")) == 3
+    assert results.exit_code(results.err(results.AUTH_DENIED, "m")) == 4
+    assert results.exit_code(results.err(results.STORAGE, "m")) == 5
+    assert results.exit_code(results.err(results.INTERNAL, "m")) == 1
+
+
+def test_core_operations_never_read_environ() -> None:
+    """Spec invariant: the domain layer never reads the process environment.
+
+    AST-based so docstrings/comments mentioning the rule don't trip it.
+    """
+    import ast
+
+    tree = ast.parse(Path(operations.__file__).read_text(encoding="utf-8"))
+    banned: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "environ"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+        ):
+            banned.append("os.environ")
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getenv"
+        ):
+            banned.append("getenv()")
+    assert banned == [], f"domain layer reads environment: {banned}"

--- a/tests/test_mnemo_pilot_equivalence.py
+++ b/tests/test_mnemo_pilot_equivalence.py
@@ -1,0 +1,156 @@
+"""P0 equivalence gate: CLI and MCP-shaped handler must observe identical
+envelopes for identical operations (TOOL-1 acceptance).
+
+Neither surface invokes the other: the CLI path goes through
+``mnemo_cli.__main__.main`` (argparse -> core) and the MCP path through
+``mnemo_mcp.pilot_tools`` (args dict -> core). Envelopes are canonicalized
+(masking freshly generated ids/timestamps, sorting keys) and compared as
+strings — any other difference fails the gate.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mnemo_cli.__main__ import main as cli_main
+from mnemo_mcp import pilot_tools
+from mnemo_mcp.db import MemoryDB
+
+
+def _canonical(envelope: dict) -> str:
+    """Canonical form with volatile fields (fresh ids, timestamps) masked.
+
+    Each surface runs against its own store file, so freshly generated ids
+    can never match; the equivalence property is byte-equality modulo those.
+    """
+
+    def scrub(obj: object) -> object:
+        if isinstance(obj, dict):
+            return {
+                k: (
+                    "<id>"
+                    if k == "id"
+                    else (
+                        "<ts>"
+                        if k in ("created_at", "updated_at", "last_accessed")
+                        else scrub(v)
+                    )
+                )
+                for k, v in obj.items()
+            }
+        if isinstance(obj, list):
+            return [scrub(v) for v in obj]
+        return obj
+
+    return json.dumps(
+        scrub(json.loads(json.dumps(envelope))), sort_keys=True, ensure_ascii=False
+    )
+
+
+def _run_cli(argv: list[str], capsys: pytest.CaptureFixture[str]) -> tuple[str, int]:
+    code = cli_main(argv)
+    return capsys.readouterr().out.strip(), code
+
+
+SCENARIOS: list[tuple[str, dict[str, Any]]] = [
+    (
+        "capture",
+        {"content": "deploy checklist for pilot", "tags": ["ops"], "category": "tech"},
+    ),
+    ("capture", {"content": ""}),  # VALIDATION
+    ("recall", {"query": "deploy checklist", "k": 5}),
+    ("recall", {"query": "   "}),  # VALIDATION
+    ("fetch", {"memory_id": "deadbeef"}),  # NOT_FOUND
+    ("fetch", {"memory_id": ""}),  # VALIDATION
+]
+
+_HANDLERS = {
+    "capture": pilot_tools.pilot_capture,
+    "recall": pilot_tools.pilot_recall,
+    "fetch": pilot_tools.pilot_fetch,
+}
+
+
+def test_cli_and_mcp_envelopes_are_byte_equal(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    for i, (op, args) in enumerate(SCENARIOS):
+        # Fresh, isolated store pair per scenario: identical starting state
+        # on both surfaces, so envelope equality is purely surface equality.
+        cli_db = tmp_path / f"cli-{i}.db"
+        mcp_store = MemoryDB(tmp_path / f"mcp-{i}.db", embedding_dims=0)
+        cli_args: list[str] = ["--db", str(cli_db), "--subject", "alice"]
+        if op == "capture":
+            cli_args += [args["content"]]
+            if "tags" in args:
+                cli_args += ["--tags", ",".join(args["tags"])]
+            if "category" in args and args["category"] != "general":
+                cli_args += ["--category", args["category"]]
+        elif op == "recall":
+            cli_args += [args["query"], "--k", str(args.get("k", 5))]
+        else:
+            cli_args += [args["memory_id"]]
+
+        cli_out, cli_code = _run_cli([op, *cli_args], capsys)
+        cli_env = json.loads(cli_out)
+        mcp_env = _HANDLERS[op](mcp_store, "alice", args)
+        mcp_code = 0 if mcp_env.get("ok") else 1
+        mcp_store.close()
+
+        assert _canonical(cli_env) == _canonical(mcp_env), (
+            f"envelope mismatch for {op} {args}"
+        )
+        assert (cli_env["ok"] is True) == (cli_code == 0)
+        assert (mcp_env["ok"] is True) == (mcp_code == 0)
+
+
+def test_happy_capture_recall_round_trip_both_surfaces(
+    two_stores: tuple[MemoryDB, MemoryDB],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _, mcp_store = two_stores
+    cli_out, _ = _run_cli(
+        [
+            "capture",
+            "--db",
+            str(tmp_path / "rt-cli.db"),
+            "--subject",
+            "alice",
+            "gamma release notes",
+        ],
+        capsys,
+    )
+    captured = json.loads(cli_out)
+
+    # The CLI wrote rt-cli.db; an MCP-shaped handler reading the SAME store
+    # must observe the memory the CLI captured (shared core, shared data).
+    rt_store = MemoryDB(tmp_path / "rt-cli.db", embedding_dims=0)
+    try:
+        fetched = pilot_tools.pilot_fetch(
+            rt_store, "alice", {"memory_id": captured["data"]["id"]}
+        )
+        assert fetched["ok"] is True
+        assert fetched["data"]["memory"]["content"] == "gamma release notes"
+    finally:
+        rt_store.close()
+
+    # A different subject store sees nothing (isolation, exercised via MCP).
+    recalled = pilot_tools.pilot_recall(mcp_store, "bob", {"query": "gamma release"})
+    assert recalled["ok"] is True
+    assert recalled["data"]["matches"] == []
+
+
+@pytest.fixture
+def two_stores(tmp_path: Path) -> Generator[tuple[MemoryDB, MemoryDB]]:
+    cli_store = MemoryDB(tmp_path / "cli.db", embedding_dims=0)
+    mcp_store = MemoryDB(tmp_path / "mcp.db", embedding_dims=0)
+    yield cli_store, mcp_store
+    cli_store.close()
+    mcp_store.close()


### PR DESCRIPTION
Implements P0 of the mnemo pilot design (TOOL-1): mnemo_core domain layer (capture/recall/fetch over a StoragePort, shared envelope + 5-code error taxonomy, environment-free enforced by AST-guarded test), mnemo-pilot CLI console script (taxonomy exit codes), MCP-shaped pilot handlers (FastMCP registration lands in P0.1), and the equivalence gate requiring identical canonical envelopes (ids/timestamps masked) from both surfaces. Existing rich server tools untouched - full migration to core lands with P1/MN-1. Design: n24q02m/.private specs/2026-09-10-mnemo-pilot-mn1-6-tool1-design.md (user-accepted 2026-09-10). Local: pilot suite green; CLI smoke verified end-to-end against a live migrated store; no paid calls, no network in tests.