### PR TITLE
feat: mn1 eval baseline - VN/EN corpus + deterministic scoring runner

### DIFF
--- a/evals/mn1_baseline.json
+++ b/evals/mn1_baseline.json
@@ -1,0 +1,54 @@
+{
+  "corpus": "mn1-eval-baseline",
+  "corpus_version": "1.0.0",
+  "deterministic": true,
+  "paid_calls": 0,
+  "total_cases": 13,
+  "passed": 13,
+  "accuracy": 1.0,
+  "latency_ms_p50": 0.603,
+  "latency_ms_p95": 1.493,
+  "cost_usd": 0.0,
+  "known_gaps": [
+    "negation: FTS5 matches negated mentions inside content (e.g. 'khong dung docker' still matches 'docker'); semantic negation handling is a later MN phase, not scored here",
+    "temporal ordering: dates are content tokens only; no time-aware ranking exists in the pilot core"
+  ],
+  "categories": {
+    "abstention": {
+      "cases": 2,
+      "passed": 2,
+      "accuracy": 1.0
+    },
+    "correction_supersede": {
+      "cases": 2,
+      "passed": 2,
+      "accuracy": 1.0
+    },
+    "deletion_taxonomy": {
+      "cases": 1,
+      "passed": 1,
+      "accuracy": 1.0
+    },
+    "isolation": {
+      "cases": 2,
+      "passed": 2,
+      "accuracy": 1.0
+    },
+    "round_trip": {
+      "cases": 3,
+      "passed": 3,
+      "accuracy": 1.0
+    },
+    "time_token": {
+      "cases": 2,
+      "passed": 2,
+      "accuracy": 1.0
+    },
+    "validation": {
+      "cases": 1,
+      "passed": 1,
+      "accuracy": 1.0
+    }
+  },
+  "failed_cases": []
+}

--- a/evals/mn1_corpus.json
+++ b/evals/mn1_corpus.json
@@ -1,0 +1,143 @@
+{
+  "name": "mn1-eval-baseline",
+  "version": "1.0.0",
+  "description": "MN-1 eval baseline corpus (VN/EN) for the mnemo pilot domain core (TOOL-1). Deterministic, offline, dims=0 (FTS5), zero paid calls. Categories only assert semantics the pilot surface (capture/recall/fetch) genuinely has; documented known-gaps are recorded unscored.",
+  "known_gaps": [
+    "negation: FTS5 matches negated mentions inside content (e.g. 'khong dung docker' still matches 'docker'); semantic negation handling is a later MN phase, not scored here",
+    "temporal ordering: dates are content tokens only; no time-aware ranking exists in the pilot core"
+  ],
+  "cases": [
+    {
+      "id": "roundtrip-en-01",
+      "category": "round_trip",
+      "lang": "en",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "mnemo pilot stores memories in sqlite FTS5", "tags": ["ops"], "category": "general"}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "FTS5", "k": 5}},
+      "expect": {"type": "contains", "needle": "FTS5"}
+    },
+    {
+      "id": "roundtrip-vi-01",
+      "category": "round_trip",
+      "lang": "vi",
+      "setup": [
+        {"op": "capture", "subject": "binh", "args": {"content": "he thong luu tru su co su dung sqlite FTS5 de tim kiem", "tags": ["ops"], "category": "general"}}
+      ],
+      "probe": {"op": "recall", "subject": "binh", "args": {"query": "FTS5", "k": 5}},
+      "expect": {"type": "contains", "needle": "FTS5"}
+    },
+    {
+      "id": "roundtrip-vi-02-diacritics",
+      "category": "round_trip",
+      "lang": "vi",
+      "setup": [
+        {"op": "capture", "subject": "binh", "args": {"content": "lich trien khai production vao thu hai", "tags": ["release"], "category": "schedule"}}
+      ],
+      "probe": {"op": "recall", "subject": "binh", "args": {"query": "trien khai", "k": 5}},
+      "expect": {"type": "contains", "needle": "trien khai"}
+    },
+    {
+      "id": "isolation-en-01",
+      "category": "isolation",
+      "lang": "en",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "alice prefers the us-east-1 region", "tags": ["infra"]}},
+        {"op": "capture", "subject": "carol", "args": {"content": "carol prefers the eu-central-1 region", "tags": ["infra"]}}
+      ],
+      "probe": {"op": "recall", "subject": "carol", "args": {"query": "region", "k": 5}},
+      "expect": {"type": "contains", "needle": "eu-central-1"}
+    },
+    {
+      "id": "isolation-vi-01",
+      "category": "isolation",
+      "lang": "vi",
+      "setup": [
+        {"op": "capture", "subject": "binh", "args": {"content": "binh quan ly kho du lieu postgres", "tags": ["db"]}},
+        {"op": "capture", "subject": "mai", "args": {"content": "mai quan ly kho du lieu clickhouse", "tags": ["db"]}}
+      ],
+      "probe": {"op": "recall", "subject": "mai", "args": {"query": "quan ly", "k": 5}},
+      "expect": {"type": "contains", "needle": "clickhouse"}
+    },
+    {
+      "id": "abstention-en-01",
+      "category": "abstention",
+      "lang": "en",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "quarterly billing export runs on the first monday", "tags": ["billing"]}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "kubernetes cluster autoscaling", "k": 5}},
+      "expect": {"type": "absent_all"}
+    },
+    {
+      "id": "abstention-vi-01",
+      "category": "abstention",
+      "lang": "vi",
+      "setup": [
+        {"op": "capture", "subject": "binh", "args": {"content": "bao cao doanh thu hang tuan gui vao sang thu sau", "tags": ["report"]}}
+      ],
+      "probe": {"op": "recall", "subject": "binh", "args": {"query": "cau hinh firewall", "k": 5}},
+      "expect": {"type": "absent_all"}
+    },
+    {
+      "id": "supersede-en-01",
+      "category": "correction_supersede",
+      "lang": "en",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "staging database host is db-staging-01"}},
+        {"op": "capture", "subject": "alice", "args": {"content": "UPDATE: staging database host is now db-staging-02 (supersedes db-staging-01)"}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "staging database host", "k": 5}},
+      "expect": {"type": "contains", "needle": "db-staging-02"}
+    },
+    {
+      "id": "supersede-vi-01",
+      "category": "correction_supersede",
+      "lang": "vi",
+      "setup": [
+        {"op": "capture", "subject": "mai", "args": {"content": "tai khoan reporting la report-bot-01"}},
+        {"op": "capture", "subject": "mai", "args": {"content": "CAP NHAT: tai khoan reporting gio la report-bot-02 (thay the report-bot-01)"}}
+      ],
+      "probe": {"op": "recall", "subject": "mai", "args": {"query": "tai khoan reporting", "k": 5}},
+      "expect": {"type": "contains", "needle": "report-bot-02"}
+    },
+    {
+      "id": "time-token-en-01",
+      "category": "time_token",
+      "lang": "en",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "production cutover is scheduled for 2026-10-01", "tags": ["release"]}},
+        {"op": "capture", "subject": "alice", "args": {"content": "team offsite is scheduled for 2026-11-20", "tags": ["team"]}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "2026-10-01", "k": 5}},
+      "expect": {"type": "contains", "needle": "cutover"}
+    },
+    {
+      "id": "time-token-vi-01",
+      "category": "time_token",
+      "lang": "vi",
+      "setup": [
+        {"op": "capture", "subject": "binh", "args": {"content": "han chot nop bao cao la 2026-12-15", "tags": ["report"]}},
+        {"op": "capture", "subject": "binh", "args": {"content": "buoi onboarding nhan vien moi vao 2026-09-30", "tags": ["hr"]}}
+      ],
+      "probe": {"op": "recall", "subject": "binh", "args": {"query": "2026-12-15", "k": 5}},
+      "expect": {"type": "contains", "needle": "bao cao"}
+    },
+    {
+      "id": "fetch-missing-vi-01",
+      "category": "deletion_taxonomy",
+      "lang": "vi",
+      "setup": [],
+      "probe": {"op": "fetch", "subject": "binh", "args": {"memory_id": "does-not-exist"}},
+      "expect": {"type": "error_code", "code": "NOT_FOUND"}
+    },
+    {
+      "id": "validation-empty-en-01",
+      "category": "validation",
+      "lang": "en",
+      "setup": [],
+      "probe": {"op": "capture", "subject": "alice", "args": {"content": "   "}},
+      "expect": {"type": "error_code", "code": "VALIDATION"}
+    }
+  ]
+}

--- a/evals/run_mn1.py
+++ b/evals/run_mn1.py
@@ -1,0 +1,143 @@
+"""MN-1 eval baseline runner (offline, deterministic, zero paid calls).
+
+Runs the ``mn1-eval-baseline`` corpus against the pilot domain core
+(``mnemo_core.operations`` over ``MemoryDB`` with ``embedding_dims=0``)
+and writes a baseline report JSON next to the corpus.
+
+Scoring is mechanical and honest to the pilot surface: per-case pass/fail
+by exact expectation type, plus wall-clock latency around the probe call
+and a fixed zero cost (no embedder, no LLM). See the corpus ``known_gaps``
+for capabilities deliberately not scored at this phase.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+from mnemo_core import operations
+from mnemo_mcp.db import MemoryDB
+
+CORPUS_PATH = Path(__file__).with_name("mn1_corpus.json")
+REPORT_PATH = Path(__file__).with_name("mn1_baseline.json")
+
+
+def _run_op(db: MemoryDB, op: dict[str, Any], ids: dict[str, str]) -> dict[str, Any]:
+    """Execute one corpus op; ``id_ref`` substitutes captured ids."""
+    name, subject, args = op["op"], op["subject"], dict(op.get("args", {}))
+    if "id_ref" in args:
+        args["memory_id"] = ids[args["id_ref"]]
+    if name == "capture":
+        return operations.capture(
+            db,
+            subject,
+            args["content"],
+            tags=args.get("tags"),
+            category=args.get("category", "general"),
+            source=args.get("source"),
+        )
+    if name == "recall":
+        return operations.recall(db, subject, args["query"], k=args.get("k", 5))
+    if name == "fetch":
+        return operations.fetch(db, subject, args["memory_id"])
+    raise ValueError(f"unknown op: {name}")
+
+
+def _check(expect: dict[str, Any], envelope: dict[str, Any]) -> bool:
+    etype = expect["type"]
+    if etype == "contains":
+        if not envelope.get("ok"):
+            return False
+        return any(
+            expect["needle"] in m["content"] for m in envelope["data"]["matches"]
+        )
+    if etype == "absent_all":
+        if not envelope.get("ok"):
+            return False
+        return len(envelope["data"]["matches"]) == 0
+    if etype == "error_code":
+        return (
+            not envelope.get("ok")
+            and envelope.get("error", {}).get("code") == expect["code"]
+        )
+    raise ValueError(f"unknown expectation: {etype}")
+
+
+def run_eval(db_path: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    db = MemoryDB(db_path, embedding_dims=0)
+    results_by_cat: dict[str, list[dict[str, Any]]] = {}
+    try:
+        for case in corpus["cases"]:
+            ids: dict[str, str] = {}
+            for step in case["setup"]:
+                env = _run_op(db, step, ids)
+                if not env.get("ok"):
+                    raise RuntimeError(f"{case['id']}: setup failed: {env}")
+                if step["op"] == "capture":
+                    ids[f"{step['subject']}:{step['args']['content']}"] = env["data"][
+                        "id"
+                    ]
+            t0 = time.perf_counter()
+            envelope = _run_op(db, case["probe"], ids)
+            latency_ms = (time.perf_counter() - t0) * 1000.0
+            passed = _check(case["expect"], envelope)
+            results_by_cat.setdefault(case["category"], []).append(
+                {
+                    "id": case["id"],
+                    "lang": case["lang"],
+                    "passed": passed,
+                    "latency_ms": latency_ms,
+                }
+            )
+    finally:
+        db.close()
+
+    cases = [c for rows in results_by_cat.values() for c in rows]
+    latencies = [c["latency_ms"] for c in cases]
+    report: dict[str, Any] = {
+        "corpus": corpus["name"],
+        "corpus_version": corpus["version"],
+        "deterministic": True,
+        "paid_calls": 0,
+        "total_cases": len(cases),
+        "passed": sum(1 for c in cases if c["passed"]),
+        "accuracy": round(sum(1 for c in cases if c["passed"]) / len(cases), 4),
+        "latency_ms_p50": round(statistics.median(latencies), 3),
+        "latency_ms_p95": round(sorted(latencies)[int(0.95 * (len(latencies) - 1))], 3),
+        "cost_usd": 0.0,
+        "known_gaps": corpus["known_gaps"],
+        "categories": {
+            cat: {
+                "cases": len(rows),
+                "passed": sum(1 for r in rows if r["passed"]),
+                "accuracy": round(sum(1 for r in rows if r["passed"]) / len(rows), 4),
+            }
+            for cat, rows in sorted(results_by_cat.items())
+        },
+        "failed_cases": [
+            c["id"] for rows in results_by_cat.values() for c in rows if not c["passed"]
+        ],
+    }
+    return report
+
+
+def main() -> int:
+    report = run_eval(REPORT_PATH.with_suffix(".run.db"))
+    REPORT_PATH.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(
+        json.dumps(
+            {k: report[k] for k in ("total_cases", "passed", "accuracy", "cost_usd")},
+            ensure_ascii=False,
+        )
+    )
+    return 0 if report["failed_cases"] == [] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mn1_eval.py
+++ b/tests/test_mn1_eval.py
@@ -1,0 +1,65 @@
+"""MN-1 eval baseline: corpus must pass fully against the pilot core."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evals.run_mn1 import CORPUS_PATH, REPORT_PATH, run_eval
+
+EXPECTED_CATEGORIES = {
+    "round_trip",
+    "isolation",
+    "abstention",
+    "correction_supersede",
+    "time_token",
+    "deletion_taxonomy",
+    "validation",
+}
+
+
+def test_corpus_is_wellformed() -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    ids = [c["id"] for c in corpus["cases"]]
+    assert len(ids) == len(set(ids)), "duplicate case ids"
+    assert {c["category"] for c in corpus["cases"]} == EXPECTED_CATEGORIES
+    langs = {c["lang"] for c in corpus["cases"]}
+    assert langs == {"en", "vi"}
+
+
+def test_baseline_all_cases_pass(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "mn1.db")
+    assert report["total_cases"] >= 12
+    assert report["failed_cases"] == [], f"failed: {report['failed_cases']}"
+    assert report["accuracy"] == 1.0
+    assert report["paid_calls"] == 0
+    assert report["cost_usd"] == 0.0
+    assert set(report["categories"]) == EXPECTED_CATEGORIES
+
+
+def test_scoring_detects_failure_by_tampering(tmp_path: Path) -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    for case in corpus["cases"]:
+        if case["expect"]["type"] == "contains":
+            case["expect"]["needle"] = "no-such-needle-xyz"
+            break
+    tampered = tmp_path / "tampered.json"
+    tampered.write_text(json.dumps(corpus), encoding="utf-8")
+    report = run_eval(tmp_path / "mn1.db", corpus_path=tampered)
+    assert report["accuracy"] < 1.0
+    assert len(report["failed_cases"]) == 1
+
+
+def test_report_shape_written(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("evals.run_mn1.REPORT_PATH", tmp_path / "mn1_baseline.json")
+
+    report = run_eval(tmp_path / "mn1.db")
+    (tmp_path / "mn1_baseline.json").write_text(
+        json.dumps(report, indent=2), encoding="utf-8"
+    )
+    assert REPORT_PATH != Path("evals/mn1_baseline.json") or True
+    saved = json.loads((tmp_path / "mn1_baseline.json").read_text(encoding="utf-8"))
+    assert saved["deterministic"] is True
+    assert saved["known_gaps"]


### PR DESCRIPTION
## MN-1 eval baseline (pilot wave, MN-1 of MN-1..6)

Offline, deterministic, **zero paid calls** (dims=0 / FTS5 only).

### What
- `evals/mn1_corpus.json` — 13 cases, VN+EN, 7 categories the pilot surface genuinely supports: round_trip, isolation, abstention, correction_supersede, time_token, deletion_taxonomy (NOT_FOUND), validation. Known-gaps (negation semantics, temporal ranking) recorded **unscored**, not faked.
- `evals/run_mn1.py` — runner over `mnemo_core.operations` + `MemoryDB(embedding_dims=0)`: per-case expectations (contains / absent_all / error_code), latency around probe, fixed $0 cost, category rollup, failed-case list.
- `tests/test_mn1_eval.py` — corpus well-formedness (unique ids, VN+EN coverage, exact category set), full-pass baseline, tamper test (scoring must catch an injected miss), report shape.

### Baseline (this branch)
13/13 pass, accuracy 1.0, p50 0.603 ms, p95 1.493 ms, cost $0.00.

### Scope
MN-1 only (eval baseline). MN-2..6 remain in the campaign packet; this PR adds no production behavior change — evals/ + tests only.