### PR TITLE
fix: mn1 eval uses per-case stores, honest subject-scoping leak probes

### DIFF
--- a/evals/mn1_baseline.json
+++ b/evals/mn1_baseline.json
@@ -3,15 +3,19 @@
   "corpus_version": "1.0.0",
   "deterministic": true,
   "paid_calls": 0,
+  "per_case_stores": true,
   "total_cases": 13,
   "passed": 13,
   "accuracy": 1.0,
-  "latency_ms_p50": 0.603,
-  "latency_ms_p95": 1.493,
+  "latency_ms_p50": 0.807,
+  "latency_ms_p95": 0.978,
   "cost_usd": 0.0,
+  "subject_scoping_enforced": false,
   "known_gaps": [
     "negation: FTS5 matches negated mentions inside content (e.g. 'khong dung docker' still matches 'docker'); semantic negation handling is a later MN phase, not scored here",
-    "temporal ordering: dates are content tokens only; no time-aware ranking exists in the pilot core"
+    "temporal ordering: dates are content tokens only; no time-aware ranking exists in the pilot core",
+    "subject scoping: recall passes no subject to the storage search (operations.recall -> store.search(query, limit)), so cross-subject rows leak into matches; leak probes record this informationally (subject_scoping_enforced) and it is not scored",
+    "no update/delete op in the pilot core: corrections are supersede-by-new-capture; hard deletion is not expressible at this tier (missing_fetch_taxonomy only pins the NOT_FOUND envelope)"
   ],
   "categories": {
     "abstention": {
@@ -24,14 +28,14 @@
       "passed": 2,
       "accuracy": 1.0
     },
-    "deletion_taxonomy": {
-      "cases": 1,
-      "passed": 1,
-      "accuracy": 1.0
-    },
-    "isolation": {
+    "isolation_leak_probe": {
       "cases": 2,
       "passed": 2,
+      "accuracy": 1.0
+    },
+    "missing_fetch_taxonomy": {
+      "cases": 1,
+      "passed": 1,
       "accuracy": 1.0
     },
     "round_trip": {

--- a/evals/mn1_corpus.json
+++ b/evals/mn1_corpus.json
@@ -4,7 +4,9 @@
   "description": "MN-1 eval baseline corpus (VN/EN) for the mnemo pilot domain core (TOOL-1). Deterministic, offline, dims=0 (FTS5), zero paid calls. Categories only assert semantics the pilot surface (capture/recall/fetch) genuinely has; documented known-gaps are recorded unscored.",
   "known_gaps": [
     "negation: FTS5 matches negated mentions inside content (e.g. 'khong dung docker' still matches 'docker'); semantic negation handling is a later MN phase, not scored here",
-    "temporal ordering: dates are content tokens only; no time-aware ranking exists in the pilot core"
+    "temporal ordering: dates are content tokens only; no time-aware ranking exists in the pilot core",
+    "subject scoping: recall passes no subject to the storage search (operations.recall -> store.search(query, limit)), so cross-subject rows leak into matches; leak probes record this informationally (subject_scoping_enforced) and it is not scored",
+    "no update/delete op in the pilot core: corrections are supersede-by-new-capture; hard deletion is not expressible at this tier (missing_fetch_taxonomy only pins the NOT_FOUND envelope)"
   ],
   "cases": [
     {
@@ -32,32 +34,32 @@
       "category": "round_trip",
       "lang": "vi",
       "setup": [
-        {"op": "capture", "subject": "binh", "args": {"content": "lich trien khai production vao thu hai", "tags": ["release"], "category": "schedule"}}
+        {"op": "capture", "subject": "binh", "args": {"content": "lịch triển khai production vào thứ hai", "tags": ["release"], "category": "schedule"}}
       ],
-      "probe": {"op": "recall", "subject": "binh", "args": {"query": "trien khai", "k": 5}},
-      "expect": {"type": "contains", "needle": "trien khai"}
+      "probe": {"op": "recall", "subject": "binh", "args": {"query": "triển khai", "k": 5}},
+      "expect": {"type": "contains", "needle": "triển khai"}
     },
     {
       "id": "isolation-en-01",
-      "category": "isolation",
+      "category": "isolation_leak_probe",
       "lang": "en",
       "setup": [
         {"op": "capture", "subject": "alice", "args": {"content": "alice prefers the us-east-1 region", "tags": ["infra"]}},
         {"op": "capture", "subject": "carol", "args": {"content": "carol prefers the eu-central-1 region", "tags": ["infra"]}}
       ],
       "probe": {"op": "recall", "subject": "carol", "args": {"query": "region", "k": 5}},
-      "expect": {"type": "contains", "needle": "eu-central-1"}
+      "expect": {"type": "contains_with_leak_probe", "needle": "eu-central-1", "must_not": "us-east-1"}
     },
     {
       "id": "isolation-vi-01",
-      "category": "isolation",
+      "category": "isolation_leak_probe",
       "lang": "vi",
       "setup": [
         {"op": "capture", "subject": "binh", "args": {"content": "binh quan ly kho du lieu postgres", "tags": ["db"]}},
         {"op": "capture", "subject": "mai", "args": {"content": "mai quan ly kho du lieu clickhouse", "tags": ["db"]}}
       ],
       "probe": {"op": "recall", "subject": "mai", "args": {"query": "quan ly", "k": 5}},
-      "expect": {"type": "contains", "needle": "clickhouse"}
+      "expect": {"type": "contains_with_leak_probe", "needle": "clickhouse", "must_not": "postgres"}
     },
     {
       "id": "abstention-en-01",
@@ -125,7 +127,7 @@
     },
     {
       "id": "fetch-missing-vi-01",
-      "category": "deletion_taxonomy",
+      "category": "missing_fetch_taxonomy",
       "lang": "vi",
       "setup": [],
       "probe": {"op": "fetch", "subject": "binh", "args": {"memory_id": "does-not-exist"}},

--- a/evals/run_mn1.py
+++ b/evals/run_mn1.py
@@ -4,10 +4,12 @@ Runs the ``mn1-eval-baseline`` corpus against the pilot domain core
 (``mnemo_core.operations`` over ``MemoryDB`` with ``embedding_dims=0``)
 and writes a baseline report JSON next to the corpus.
 
-Scoring is mechanical and honest to the pilot surface: per-case pass/fail
-by exact expectation type, plus wall-clock latency around the probe call
-and a fixed zero cost (no embedder, no LLM). See the corpus ``known_gaps``
-for capabilities deliberately not scored at this phase.
+Determinism contract (mirrors the pilot's own anti-order-dependence
+pattern): every case runs against its OWN fresh DB file; scoring uses
+deterministic envelope outcomes only (exact substring membership, match
+counts, error-taxonomy codes) — never prose similarity. Latency wraps the
+probe call; cost is fixed at zero (no embedder, no LLM). See the corpus
+``known_gaps`` for semantics the pilot tier deliberately does not claim.
 """
 
 from __future__ import annotations
@@ -46,32 +48,49 @@ def _run_op(db: MemoryDB, op: dict[str, Any], ids: dict[str, str]) -> dict[str, 
     raise ValueError(f"unknown op: {name}")
 
 
-def _check(expect: dict[str, Any], envelope: dict[str, Any]) -> bool:
+def _check(
+    expect: dict[str, Any], envelope: dict[str, Any]
+) -> tuple[bool, dict[str, Any]]:
+    """Score one expectation; returns (passed, informational extras)."""
     etype = expect["type"]
+    extras: dict[str, Any] = {}
     if etype == "contains":
         if not envelope.get("ok"):
-            return False
-        return any(
-            expect["needle"] in m["content"] for m in envelope["data"]["matches"]
-        )
+            return False, extras
+        matches = [m["content"] for m in envelope["data"]["matches"]]
+        return any(expect["needle"] in c for c in matches), extras
+    if etype == "contains_with_leak_probe":
+        # Scored: own needle present. Informational: does the other
+        # subject's row leak into the same result set? The pilot core's
+        # recall passes no subject to the storage search, so leakage is
+        # expected and recorded, not scored.
+        if not envelope.get("ok"):
+            return False, extras
+        matches = [m["content"] for m in envelope["data"]["matches"]]
+        passed = any(expect["needle"] in c for c in matches)
+        extras["leaked"] = any(expect["must_not"] in c for c in matches)
+        return passed, extras
     if etype == "absent_all":
         if not envelope.get("ok"):
-            return False
-        return len(envelope["data"]["matches"]) == 0
+            return False, extras
+        return len(envelope["data"]["matches"]) == 0, extras
     if etype == "error_code":
         return (
             not envelope.get("ok")
             and envelope.get("error", {}).get("code") == expect["code"]
-        )
+        ), extras
     raise ValueError(f"unknown expectation: {etype}")
 
 
-def run_eval(db_path: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
+def run_eval(run_dir: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
     corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
-    db = MemoryDB(db_path, embedding_dims=0)
+    run_dir.mkdir(parents=True, exist_ok=True)
     results_by_cat: dict[str, list[dict[str, Any]]] = {}
-    try:
-        for case in corpus["cases"]:
+    leaked_probes = 0
+    leak_probes = 0
+    for case in corpus["cases"]:
+        db = MemoryDB(run_dir / f"{case['id']}.db", embedding_dims=0)
+        try:
             ids: dict[str, str] = {}
             for step in case["setup"]:
                 env = _run_op(db, step, ids)
@@ -84,17 +103,20 @@ def run_eval(db_path: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
             t0 = time.perf_counter()
             envelope = _run_op(db, case["probe"], ids)
             latency_ms = (time.perf_counter() - t0) * 1000.0
-            passed = _check(case["expect"], envelope)
-            results_by_cat.setdefault(case["category"], []).append(
-                {
-                    "id": case["id"],
-                    "lang": case["lang"],
-                    "passed": passed,
-                    "latency_ms": latency_ms,
-                }
-            )
-    finally:
-        db.close()
+        finally:
+            db.close()
+        passed, extras = _check(case["expect"], envelope)
+        row: dict[str, Any] = {
+            "id": case["id"],
+            "lang": case["lang"],
+            "passed": passed,
+            "latency_ms": latency_ms,
+        }
+        if "leaked" in extras:
+            row["leaked"] = extras["leaked"]
+            leak_probes += 1
+            leaked_probes += 1 if extras["leaked"] else 0
+        results_by_cat.setdefault(case["category"], []).append(row)
 
     cases = [c for rows in results_by_cat.values() for c in rows]
     latencies = [c["latency_ms"] for c in cases]
@@ -103,12 +125,14 @@ def run_eval(db_path: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
         "corpus_version": corpus["version"],
         "deterministic": True,
         "paid_calls": 0,
+        "per_case_stores": True,
         "total_cases": len(cases),
         "passed": sum(1 for c in cases if c["passed"]),
         "accuracy": round(sum(1 for c in cases if c["passed"]) / len(cases), 4),
         "latency_ms_p50": round(statistics.median(latencies), 3),
         "latency_ms_p95": round(sorted(latencies)[int(0.95 * (len(latencies) - 1))], 3),
         "cost_usd": 0.0,
+        "subject_scoping_enforced": leaked_probes == 0 if leak_probes else None,
         "known_gaps": corpus["known_gaps"],
         "categories": {
             cat: {
@@ -126,7 +150,7 @@ def run_eval(db_path: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
 
 
 def main() -> int:
-    report = run_eval(REPORT_PATH.with_suffix(".run.db"))
+    report = run_eval(REPORT_PATH.with_suffix(".run"))
     REPORT_PATH.write_text(
         json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )

--- a/tests/test_mn1_eval.py
+++ b/tests/test_mn1_eval.py
@@ -5,17 +5,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from evals.run_mn1 import CORPUS_PATH, REPORT_PATH, run_eval
 
 EXPECTED_CATEGORIES = {
     "round_trip",
-    "isolation",
+    "isolation_leak_probe",
     "abstention",
     "correction_supersede",
     "time_token",
-    "deletion_taxonomy",
+    "missing_fetch_taxonomy",
     "validation",
 }
 
@@ -27,16 +25,33 @@ def test_corpus_is_wellformed() -> None:
     assert {c["category"] for c in corpus["cases"]} == EXPECTED_CATEGORIES
     langs = {c["lang"] for c in corpus["cases"]}
     assert langs == {"en", "vi"}
+    gaps = " ".join(corpus["known_gaps"])
+    assert "subject scoping" in gaps and "no update/delete" in gaps
 
 
 def test_baseline_all_cases_pass(tmp_path: Path) -> None:
-    report = run_eval(tmp_path / "mn1.db")
+    report = run_eval(tmp_path / "run")
     assert report["total_cases"] >= 12
     assert report["failed_cases"] == [], f"failed: {report['failed_cases']}"
     assert report["accuracy"] == 1.0
-    assert report["paid_calls"] == 0
-    assert report["cost_usd"] == 0.0
-    assert set(report["categories"]) == EXPECTED_CATEGORIES
+
+
+def test_isolation_probe_records_leak_informationally(tmp_path: Path) -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    leak_cases = [c for c in corpus["cases"] if c["category"] == "isolation_leak_probe"]
+    assert len(leak_cases) == 2
+    for case in leak_cases:
+        assert case["expect"]["type"] == "contains_with_leak_probe"
+        assert case["expect"]["must_not"]
+
+
+def test_determinism_across_runs(tmp_path: Path) -> None:
+    first = run_eval(tmp_path / "a")
+    second = run_eval(tmp_path / "b")
+    assert first["accuracy"] == second["accuracy"]
+    assert first["passed"] == second["passed"]
+    assert first["categories"] == second["categories"]
+    assert first["failed_cases"] == second["failed_cases"]
 
 
 def test_scoring_detects_failure_by_tampering(tmp_path: Path) -> None:
@@ -47,19 +62,16 @@ def test_scoring_detects_failure_by_tampering(tmp_path: Path) -> None:
             break
     tampered = tmp_path / "tampered.json"
     tampered.write_text(json.dumps(corpus), encoding="utf-8")
-    report = run_eval(tmp_path / "mn1.db", corpus_path=tampered)
+    report = run_eval(tmp_path / "run", corpus_path=tampered)
     assert report["accuracy"] < 1.0
     assert len(report["failed_cases"]) == 1
 
 
-def test_report_shape_written(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("evals.run_mn1.REPORT_PATH", tmp_path / "mn1_baseline.json")
-
-    report = run_eval(tmp_path / "mn1.db")
-    (tmp_path / "mn1_baseline.json").write_text(
-        json.dumps(report, indent=2), encoding="utf-8"
-    )
-    assert REPORT_PATH != Path("evals/mn1_baseline.json") or True
-    saved = json.loads((tmp_path / "mn1_baseline.json").read_text(encoding="utf-8"))
+def test_main_report_written(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "run")
+    out = tmp_path / "mn1_baseline.json"
+    out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    saved = json.loads(out.read_text(encoding="utf-8"))
     assert saved["deterministic"] is True
     assert saved["known_gaps"]
+    assert REPORT_PATH.name == "mn1_baseline.json"


### PR DESCRIPTION
## MN-1 eval hardening (follow-up to #1202)

Audit found the v1 baseline over-claimed two things. This PR makes the baseline honest and order-independent:

### Changes
- **Per-case fresh DB files** (`{case_id}.db` under a run dir) — mirrors the pilot's own anti-order-dependence pattern; abstention/no longer order-dependent on shared store.
- **Subject-scoping truth**: `operations.recall` passes NO subject to `store.search` (operations.py:71-76) — the envelope `subject` is an echo. Isolation cases renamed to `isolation_leak_probe` with `contains_with_leak_probe` expectation: own-token presence is scored; cross-subject leak (`must_not` token) is recorded informationally per-case and surfaced as top-level `subject_scoping_enforced: false` + a known_gaps entry. No fake certification.
- **Category renames for honesty**: `deletion_taxonomy` → `missing_fetch_taxonomy` (the core has no update/delete op; only the NOT_FOUND envelope is pinned); known_gaps documents supersede-by-new-capture as the only correction mechanism.
- **Real diacritics case**: `roundtrip-vi-02-diacritics` now uses diacritics on both content and query ("lịch triển khai production vào thứ hai" / "triển khai") — FTS5 matches, verified.
- **New tests**: determinism double-run (identical accuracy/categories/failed sets), leak-probe contract, known-gaps completeness; 6/6 file-scoped.

### Baseline (this branch)
13/13 pass, accuracy 1.0, cost $0.00, `subject_scoping_enforced: false` recorded as a documented limitation — enforcement is a later MN phase, not silently certified.

### Scope
evals/ + tests only; no production behavior change. MN-2..6 remain in the campaign packet.