### PR TITLE
test: mn1 eval restores durable honesty asserts

### DIFF
--- a/tests/test_mn1_eval.py
+++ b/tests/test_mn1_eval.py
@@ -34,6 +34,14 @@ def test_baseline_all_cases_pass(tmp_path: Path) -> None:
     assert report["total_cases"] >= 12
     assert report["failed_cases"] == [], f"failed: {report['failed_cases']}"
     assert report["accuracy"] == 1.0
+    assert report["paid_calls"] == 0
+    assert report["cost_usd"] == 0.0
+    assert report["per_case_stores"] is True
+    assert set(report["categories"]) == EXPECTED_CATEGORIES
+    # Load-bearing honesty pin: the pilot recall passes no subject to the
+    # storage search, so the runner must keep recording the leak, not
+    # silently certify isolation.
+    assert report["subject_scoping_enforced"] is False
 
 
 def test_isolation_probe_records_leak_informationally(tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-up to #1203: an edit while fixing syntax accidentally dropped five load-bearing runtime asserts from `test_baseline_all_cases_pass` before merge — the suite stayed green but nothing pinned that the runner keeps recording `subject_scoping_enforced: false`, `per_case_stores`, zero paid calls/cost, or the exact category set. This restores those asserts (6/6 file-scoped pass). Test-only change; no production or corpus change.