### PR TITLE
feat: mn2 memory defense - deterministic secret/PII redaction

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+evals/run_mn2_defense.py:generic-api-key:31

--- a/evals/mn1_baseline.json
+++ b/evals/mn1_baseline.json
@@ -7,8 +7,8 @@
   "total_cases": 13,
   "passed": 13,
   "accuracy": 1.0,
-  "latency_ms_p50": 0.807,
-  "latency_ms_p95": 0.978,
+  "latency_ms_p50": 0.986,
+  "latency_ms_p95": 1.264,
   "cost_usd": 0.0,
   "subject_scoping_enforced": false,
   "known_gaps": [

--- a/evals/mn2_defense_baseline.json
+++ b/evals/mn2_defense_baseline.json
@@ -1,0 +1,16 @@
+{
+  "eval": "mn2-defense",
+  "deterministic": true,
+  "paid_calls": 0,
+  "per_case_stores": true,
+  "total_cases": 23,
+  "passed": 23,
+  "accuracy": 1.0,
+  "tp_cases": 6,
+  "tp_passed": 6,
+  "fp_cases": 17,
+  "fp_violations": [],
+  "probe_latency_ms": 0.121,
+  "cost_usd": 0.0,
+  "failed_cases": []
+}

--- a/evals/run_mn2_defense.py
+++ b/evals/run_mn2_defense.py
@@ -1,0 +1,132 @@
+"""MN-2 eval: memory defense TP/FP, deterministic, zero paid calls.
+
+True-positive side: each pattern kind must round-trip capture -> fetch
+with the secret replaced by its [REDACTED:*] marker, and the raw secret
+must not exist anywhere in the store file bytes.
+False-positive side: every benign content line of the MN-1 corpus must
+produce zero findings — redaction must not corrupt normal memories.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from mnemo_core import operations
+from mnemo_core.defense import scan
+from mnemo_mcp.db import MemoryDB
+
+MN1_CORPUS = Path(__file__).with_name("mn1_corpus.json")
+REPORT_PATH = Path(__file__).with_name("mn2_defense_baseline.json")
+
+POSITIVE_CASES = [
+    {"id": "tp-aws", "kind": "aws_access_key", "secret": "AKIAIOSFODNN7EXAMPLE"},
+    {
+        "id": "tp-ghpat",
+        "kind": "github_pat",
+        "secret": "ghp_abcdefghijklmnopqrstuvwxyzabcdefghij",
+    },
+    {"id": "tp-slack", "kind": "slack_token", "secret": "xoxb-123456789012-abcdef"},
+    {
+        "id": "tp-bearer",
+        "kind": "bearer_token",
+        "secret": "Bearer abcdef1234567890abcdef123456",
+    },
+    {"id": "tp-email", "kind": "email", "secret": "mai.nguyen@example.com"},
+    {"id": "tp-phone", "kind": "vn_phone", "secret": "0912345678"},
+]
+
+
+def _benign_lines() -> list[str]:
+    corpus = json.loads(MN1_CORPUS.read_text(encoding="utf-8"))
+    lines: list[str] = []
+    for case in corpus["cases"]:
+        for step in case["setup"]:
+            if step["op"] == "capture":
+                lines.append(step["args"]["content"])
+    return lines
+
+
+def run_eval(run_dir: Path) -> dict[str, Any]:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    latencies: list[float] = []
+
+    # --- True positives: round-trip with persistence + egress redaction ---
+    tp_passed = 0
+    failed: list[str] = []
+    for case in POSITIVE_CASES:
+        db_path = run_dir / f"{case['id']}.db"
+        db = MemoryDB(db_path, embedding_dims=0)
+        try:
+            t0 = time.perf_counter()
+            cap = operations.capture(
+                db, "alice", f"please rotate {case['secret']} before friday"
+            )
+            fetched = operations.fetch(db, "alice", cap["data"]["id"])
+            latencies.append((time.perf_counter() - t0) * 1000.0)
+        finally:
+            db.close()
+        ok = (
+            cap["data"]["redactions"] == [case["kind"]]
+            and fetched["data"]["redactions"] == []
+            and case["secret"] not in fetched["data"]["memory"]["content"]
+            and f"[REDACTED:{case['kind']}]" in fetched["data"]["memory"]["content"]
+        )
+        # raw bytes check: the secret must not survive in the store file
+        blob = db_path.read_bytes()
+        ok = ok and case["secret"].encode() not in blob
+        if ok:
+            tp_passed += 1
+        else:
+            failed.append(case["id"])
+
+    # --- False positives: every MN-1 benign line must scan clean ---
+    benign = _benign_lines()
+    fp_lines = [line for line in benign if scan(line)]
+    t0 = time.perf_counter()
+    fp_scan = [scan(line) for line in benign]
+    probe_ms = (time.perf_counter() - t0) * 1000.0
+
+    total = len(POSITIVE_CASES) + len(benign)
+    passed = tp_passed + (len(benign) - len(fp_lines))
+    report: dict[str, Any] = {
+        "eval": "mn2-defense",
+        "deterministic": True,
+        "paid_calls": 0,
+        "per_case_stores": True,
+        "total_cases": total,
+        "passed": passed,
+        "accuracy": round(passed / total, 4),
+        "tp_cases": len(POSITIVE_CASES),
+        "tp_passed": tp_passed,
+        "fp_cases": len(benign),
+        "fp_violations": [
+            {"content": line, "findings": [f["kind"] for f in finds]}
+            for line, finds in zip(benign, fp_scan, strict=False)
+            if finds
+        ],
+        "probe_latency_ms": round(probe_ms, 3),
+        "cost_usd": 0.0,
+        "failed_cases": failed,
+    }
+    return report
+
+
+def main() -> int:
+    report = run_eval(REPORT_PATH.with_suffix(".run"))
+    REPORT_PATH.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(
+        json.dumps(
+            {k: report[k] for k in ("total_cases", "passed", "accuracy", "cost_usd")},
+            ensure_ascii=False,
+        )
+    )
+    return 0 if report["failed_cases"] == [] and not report["fp_violations"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mnemo_core/defense.py
+++ b/src/mnemo_core/defense.py
@@ -1,0 +1,83 @@
+"""MN-2 memory defense: deterministic secret/PII scan + redaction.
+
+Dry tier of the memory-defense phase (spec P2): pattern-based detection,
+no ML, no network, no environment reads. ``redact`` is applied at
+persistence (capture) and again at egress (recall/fetch) so secrets that
+reached the store through other paths still never leave it.
+
+Findings carry kind and offsets only — never the matched material.
+
+Overlap rule: a finding contained inside another finding's span (e.g. a
+phone-shaped digit run inside a base62 token) is dropped — the outer
+secret's replacement removes the inner text anyway, and reporting the
+inner span as a separate hit would corrupt span-based redaction and
+inflate the false-positive metric this phase exists to measure honestly.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# (kind, compiled pattern) — order matters only for reporting, not safety.
+_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("aws_access_key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("github_pat", re.compile(r"gh[pousr]_[0-9A-Za-z]{36,255}")),
+    ("slack_token", re.compile(r"xox[abprs]-[0-9A-Za-z-]{10,}")),
+    ("bearer_token", re.compile(r"(?i)bearer\s+[a-z0-9._-]{20,}")),
+    (
+        "email",
+        re.compile(
+            r"(?<![\w.])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![\w.])"
+        ),
+    ),
+    # Bounded by alphanumerics so digit runs inside tokens (PAT bodies,
+    # slugs, hex ids) are never misread as Vietnamese phone numbers.
+    ("vn_phone", re.compile(r"(?<![0-9A-Za-z])0\d{9}(?![0-9A-Za-z])")),
+]
+
+
+def scan(text: str) -> list[dict[str, Any]]:
+    """Return non-overlapping findings; kind + offsets only.
+
+    When spans nest or overlap (inner text also matching a second
+    pattern), only the outermost finding survives — deterministic order
+    is longest span first, then pattern order.
+    """
+    raw: list[tuple[int, int, str]] = []
+    for kind, pattern in _PATTERNS:
+        for match in pattern.finditer(text):
+            raw.append((match.start(), match.end(), kind))
+    # Longest span first at equal start, then pattern order (stable).
+    raw.sort(key=lambda f: (f[0], -(f[1] - f[0])))
+    findings: list[dict[str, Any]] = []
+    last_end = -1
+    for start, end, kind in raw:
+        if start < last_end:
+            continue  # contained in / overlapping a kept finding
+        findings.append({"kind": kind, "start": start, "end": end})
+        last_end = end
+    findings.sort(key=lambda f: (f["start"], f["end"]))
+    return findings
+
+
+def redact(text: str) -> tuple[str, list[str]]:
+    """Replace every finding with ``[REDACTED:<kind>]``.
+
+    Returns the redacted text and the ordered list of redacted kinds
+    (one entry per replacement). Idempotent: already-redacted markers
+    match no pattern.
+    """
+    findings = scan(text)
+    if not findings:
+        return text, []
+    out: list[str] = []
+    kinds: list[str] = []
+    cursor = 0
+    for finding in findings:
+        out.append(text[cursor : finding["start"]])
+        out.append(f"[REDACTED:{finding['kind']}]")
+        kinds.append(finding["kind"])
+        cursor = finding["end"]
+    out.append(text[cursor:])
+    return "".join(out), kinds

--- a/src/mnemo_core/operations.py
+++ b/src/mnemo_core/operations.py
@@ -15,6 +15,7 @@ import sqlite3
 from typing import Any
 
 from mnemo_core import results
+from mnemo_core.defense import redact
 from mnemo_core.ports import StoragePort
 
 # Mirrors mnemo_mcp.db.MAX_CONTENT_LENGTH (validated at the DB layer too);
@@ -33,9 +34,10 @@ def capture(
     """Store one memory for a subject. Returns the capture envelope."""
     if content is None or not content.strip():
         return results.err(results.VALIDATION, "content is required")
+    persisted, kinds = redact(content)
     try:
         memory_id = store.add(
-            content=content,
+            content=persisted,
             category=category,
             tags=tags,
             source=source,
@@ -52,6 +54,7 @@ def capture(
             "subject": subject,
             "category": category,
             "tags": tags or [],
+            "redactions": kinds,
         }
     )
 
@@ -73,7 +76,15 @@ def recall(
         return results.err(results.STORAGE, f"recall failed: {exc}")
     except Exception as exc:  # noqa: BLE001 - taxonomy boundary
         return results.err(results.INTERNAL, f"unexpected failure: {exc}")
-    return results.ok({"subject": subject, "query": query, "matches": rows})
+    matches, egress_kinds = _redact_rows(rows)
+    return results.ok(
+        {
+            "subject": subject,
+            "query": query,
+            "matches": matches,
+            "redactions": egress_kinds,
+        }
+    )
 
 
 def fetch(
@@ -92,4 +103,27 @@ def fetch(
         return results.err(results.INTERNAL, f"unexpected failure: {exc}")
     if row is None:
         return results.err(results.NOT_FOUND, f"memory {memory_id!r} not found")
-    return results.ok({"subject": subject, "memory": row})
+    memory, kinds = _redact_row(row)
+    return results.ok({"subject": subject, "memory": memory, "redactions": kinds})
+
+
+def _redact_row(row: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Egress defense: redact stored content before it leaves the core."""
+    content = row.get("content") if isinstance(row, dict) else None
+    if not isinstance(content, str):
+        return row, []
+    persisted, kinds = redact(content)
+    if kinds:
+        row = dict(row)
+        row["content"] = persisted
+    return row, kinds
+
+
+def _redact_rows(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[str]]:
+    out: list[dict[str, Any]] = []
+    all_kinds: list[str] = []
+    for row in rows:
+        redacted, kinds = _redact_row(row)
+        out.append(redacted)
+        all_kinds.extend(kinds)
+    return out, all_kinds

--- a/tests/test_mn2_defense.py
+++ b/tests/test_mn2_defense.py
@@ -1,0 +1,123 @@
+"""MN-2 memory defense: deterministic scan/redact at persistence + egress."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from mnemo_core import operations, results
+from mnemo_core.defense import redact, scan
+from mnemo_mcp.db import MemoryDB
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Generator[MemoryDB]:
+    db = MemoryDB(tmp_path / "defense.db", embedding_dims=0)
+    yield db
+    db.close()
+
+
+SAMPLES = [
+    ("aws", "key is AKIAIOSFODNN7EXAMPLE in prod", "[REDACTED:aws_access_key]"),
+    (
+        "ghpat",
+        "token ghp_abcdefghijklmnopqrstuvwxyzabcdefghij leaked",
+        "[REDACTED:github_pat]",
+    ),
+    ("slack", "webhook xoxb-123456789012-abcdef used", "[REDACTED:slack_token]"),
+    (
+        "bearer",
+        "header: Bearer abcdef1234567890abcdef123456",
+        "[REDACTED:bearer_token]",
+    ),
+    ("email", "contact mai.nguyen@example.com for access", "[REDACTED:email]"),
+    ("phone", "goi so 0912345678 truoc 5h chieu", "[REDACTED:vn_phone]"),
+]
+
+
+@pytest.mark.parametrize("name,text,marker", SAMPLES, ids=[s[0] for s in SAMPLES])
+def test_scan_detects_each_kind(name: str, text: str, marker: str) -> None:
+    findings = scan(text)
+    assert len(findings) == 1
+    assert findings[0]["start"] < findings[0]["end"]
+
+
+@pytest.mark.parametrize("name,text,marker", SAMPLES, ids=[s[0] for s in SAMPLES])
+def test_redact_replaces_with_marker(name: str, text: str, marker: str) -> None:
+    out, kinds = redact(text)
+    assert marker in out
+    assert len(kinds) == 1
+    finding = scan(text)[0]
+    assert text[finding["start"] : finding["end"]] not in out
+
+
+def test_redact_is_idempotent() -> None:
+    once, kinds = redact("AKIAIOSFODNN7EXAMPLE")
+    twice, kinds2 = redact(once)
+    assert once == twice
+    assert kinds == ["aws_access_key"]
+    assert kinds2 == []
+
+
+def test_benign_content_untouched() -> None:
+    benign = "mnemo pilot stores memories in sqlite FTS5; lien he ho tro qua channel"
+    out, kinds = redact(benign)
+    assert out == benign
+    assert kinds == []
+
+
+def test_capture_redacts_before_persistence(store: MemoryDB) -> None:
+    env = operations.capture(store, "alice", "key AKIAIOSFODNN7EXAMPLE in notes")
+    assert env["ok"] is True
+    assert env["data"]["redactions"] == ["aws_access_key"]
+    fetched = operations.fetch(store, "alice", env["data"]["id"])
+    assert (
+        fetched["data"]["memory"]["content"] == "key [REDACTED:aws_access_key] in notes"
+    )
+
+
+def test_recall_egress_redacts_legacy_rows(store: MemoryDB) -> None:
+    """A secret inserted into the store via another path still never leaves."""
+    operations.capture(store, "alice", "innocuous note")
+    raw = "legacy blob with ghp_abcdefghijklmnopqrstuvwxyzabcdefghij inside"
+    store.add(content=raw, category="general")
+
+    env = operations.recall(store, "alice", "legacy blob")
+    assert env["ok"] is True
+    assert env["data"]["redactions"] == ["github_pat"]
+    assert all("ghp_" not in m["content"] for m in env["data"]["matches"])
+
+
+def test_redaction_never_breaks_error_taxonomy(store: MemoryDB) -> None:
+    env = operations.capture(store, "alice", "   ")
+    assert env == {
+        "ok": False,
+        "error": {"code": results.VALIDATION, "message": "content is required"},
+    }
+    assert (
+        operations.fetch(store, "alice", "missing")["error"]["code"]
+        == results.NOT_FOUND
+    )
+
+
+def test_overlapping_spans_collapse_to_outermost() -> None:
+    """Regression: a digit-bearing PAT must yield ONE finding (outer span).
+
+    The letters-only fixtures elsewhere dodge the overlap; this uses a
+    real-shaped base62 secret whose body contains a 0+9-digit run that a
+    naive vn_phone pattern would double-fire and corrupt redaction.
+    """
+    text = "token ghp_abcdefghijklmnopqrstuvwxyz0123456789abcd leaked"
+    findings = scan(text)
+    assert [f["kind"] for f in findings] == ["github_pat"]
+    out, kinds = redact(text)
+    assert kinds == ["github_pat"]
+    assert out == "token [REDACTED:github_pat] leaked"
+    assert "0123456789" not in out
+
+
+def test_phone_pattern_ignores_token_interiors() -> None:
+    assert scan("id0123456789x and ref=0987654321a") == []
+    assert scan("call 0912345678 now")[0]["kind"] == "vn_phone"

--- a/tests/test_mn2_eval.py
+++ b/tests/test_mn2_eval.py
@@ -1,0 +1,29 @@
+"""MN-2 defense eval must stay perfect and honest on every run."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.run_mn2_defense import run_eval
+
+
+def test_mn2_eval_all_pass_with_zero_false_positives(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "run")
+    assert report["failed_cases"] == [], f"TP failures: {report['failed_cases']}"
+    assert report["fp_violations"] == [], f"FP violations: {report['fp_violations']}"
+    assert report["tp_cases"] == 6
+    assert report["tp_passed"] == 6
+    assert report["fp_cases"] >= 13  # every MN-1 corpus content line
+    assert report["accuracy"] == 1.0
+    assert report["paid_calls"] == 0
+    assert report["cost_usd"] == 0.0
+    assert report["deterministic"] is True
+
+
+def test_mn2_eval_deterministic_across_runs(tmp_path: Path) -> None:
+    first = run_eval(tmp_path / "a")
+    second = run_eval(tmp_path / "b")
+    assert first["passed"] == second["passed"]
+    assert first["accuracy"] == second["accuracy"]
+    assert first["fp_violations"] == second["fp_violations"]
+    assert first["failed_cases"] == second["failed_cases"]


### PR DESCRIPTION
## MN-2 memory defense (dry wave 1, spec row P2)

Offline, deterministic, **zero paid calls**.

### What
- `mnemo_core/defense.py`: `scan()` + `redact()` over six deterministic patterns (AWS AKID, GitHub PAT, Slack token, bearer, email, VN phone). **Overlap rule**: a finding contained in another finding's span (phone-shaped digit run inside a base62 token) is dropped — outermost survives, so span-based redaction can never re-emit inner secret material and the FP metric stays honest. VN phone is bounded by alphanumerics so token interiors never fire.
- Wired into `operations`: capture redacts **before persistence**; recall/fetch redact at **egress** (legacy rows inserted via other paths still never leave). Envelope changes are additive only: `redactions` field. Findings carry kind+offsets, never the matched material.
- `evals/run_mn2_defense.py`: TP cases (6 kinds round-trip capture→fetch, marker present, raw secret absent from store **file bytes**) + FP probe (**every** MN-1 corpus content line must scan clean). Regressed overlap: digit-bearing PAT yields exactly one finding, clean marker output.
- `tests/test_mn2_defense.py` (unit + persistence + egress-legacy + taxonomy intactness) and `tests/test_mn2_eval.py` (durable asserts: 6/6 TP, 0 FP, $0, determinism double-run).

### Baselines (this branch)
- MN-2: 23/23 pass, 0 FP violations, cost $0.00.
- MN-1 regression: 13/13 unchanged (benign corpus untouched by the detector).

### Scope
Core defense + evals + tests; no surface behavior change beyond the additive `redactions` field. Known limitation recorded: overlap rule collapses to outermost kind for nested patterns.