### PR TITLE
feat: mn3 wave1 per-subject recall enforcement at storage tier

### DIFF
--- a/evals/mn1_corpus.json
+++ b/evals/mn1_corpus.json
@@ -5,7 +5,7 @@
   "known_gaps": [
     "negation: FTS5 matches negated mentions inside content (e.g. 'khong dung docker' still matches 'docker'); semantic negation handling is a later MN phase, not scored here",
     "temporal ordering: dates are content tokens only; no time-aware ranking exists in the pilot core",
-    "subject scoping: recall passes no subject to the storage search (operations.recall -> store.search(query, limit)), so cross-subject rows leak into matches; leak probes record this informationally (subject_scoping_enforced) and it is not scored",
+    "subject scoping (MN-3 enforced): scoped recall filters subject = ? at the storage tier; rows with NULL subject (legacy/unattributed) are invisible to scoped probes; subject=None recall keeps the unfiltered legacy view; leak probes verify enforcement (subject_scoping_enforced)",
     "no update/delete op in the pilot core: corrections are supersede-by-new-capture; hard deletion is not expressible at this tier (missing_fetch_taxonomy only pins the NOT_FOUND envelope)"
   ],
   "cases": [

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -103,7 +103,8 @@ CREATE TABLE IF NOT EXISTS memories (
     commit_sha TEXT,
     valid_from DATETIME,
     valid_to DATETIME,
-    superseded_by TEXT
+    superseded_by TEXT,
+    subject TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_memories_category
@@ -112,6 +113,9 @@ CREATE INDEX IF NOT EXISTS idx_memories_updated
     ON memories(updated_at);
 CREATE INDEX IF NOT EXISTS idx_memories_accessed
     ON memories(last_accessed);
+
+CREATE INDEX IF NOT EXISTS idx_memories_subject
+    ON memories(subject);
 
 -- Compound index that lets list_memories pagination
 -- (WHERE category = ? ORDER BY updated_at DESC) skip a sort.

--- a/migrations/0002_per_sub_isolation.sql
+++ b/migrations/0002_per_sub_isolation.sql
@@ -31,6 +31,7 @@ CREATE TABLE memories_v2 (
     valid_from DATETIME,
     valid_to DATETIME,
     superseded_by TEXT,
+    subject TEXT,
     PRIMARY KEY (sub, id)
 );
 
@@ -38,13 +39,13 @@ INSERT INTO memories_v2 (
     sub, id, content, category, tags, source, created_at, updated_at,
     access_count, last_accessed, importance, context_type, archived_at,
     text_raw, compressed, compression_provider, commit_sha, valid_from,
-    valid_to, superseded_by
+    valid_to, superseded_by, subject
 )
 SELECT
     'default', id, content, category, tags, source, created_at, updated_at,
     access_count, last_accessed, importance, context_type, archived_at,
     text_raw, compressed, compression_provider, commit_sha, valid_from,
-    valid_to, superseded_by
+    valid_to, superseded_by, subject
 FROM memories;
 
 CREATE TABLE archived_memories_v2 (

--- a/src/mnemo_core/operations.py
+++ b/src/mnemo_core/operations.py
@@ -41,6 +41,7 @@ def capture(
             category=category,
             tags=tags,
             source=source,
+            subject=subject,
         )
     except ValueError as exc:
         return results.err(results.VALIDATION, str(exc))
@@ -71,7 +72,7 @@ def recall(
     if k < 1:
         return results.err(results.VALIDATION, "k must be >= 1")
     try:
-        rows = store.search(query, limit=k)
+        rows = store.search(query, limit=k, subject=subject)
     except sqlite3.Error as exc:
         return results.err(results.STORAGE, f"recall failed: {exc}")
     except Exception as exc:  # noqa: BLE001 - taxonomy boundary

--- a/src/mnemo_core/ports.py
+++ b/src/mnemo_core/ports.py
@@ -19,6 +19,7 @@ class StoragePort(Protocol):
         category: str = "general",
         tags: list[str] | None = None,
         source: str | None = None,
+        subject: str | None = None,
         embedding: list[float] | None = None,
     ) -> str: ...
 
@@ -29,6 +30,8 @@ class StoragePort(Protocol):
         category: str | None = None,
         tags: list[str] | None = None,
         limit: int = 5,
+        *,
+        subject: str | None = None,
     ) -> list[dict[str, Any]]: ...
 
     def get(self, memory_id: str) -> dict[str, Any] | None: ...

--- a/src/mnemo_mcp/alembic/versions/mem_006_subject.py
+++ b/src/mnemo_mcp/alembic/versions/mem_006_subject.py
@@ -1,0 +1,43 @@
+"""MN-3: per-subject recall enforcement (subject column + index).
+
+Adds ``memories.subject TEXT`` (nullable) and ``idx_memories_subject``.
+
+Semantics (pinned in the campaign packet, 2026-09-11):
+
+* Every pilot-tier capture persists its subject; ``NULL`` subject marks a
+  legacy / unattributed row.
+* Subject-scoped search filters ``subject = ?`` — ``NULL`` rows are
+  invisible to scoped probes.
+* ``subject=None`` recall keeps the unfiltered legacy view.
+
+The migration is idempotent: the ALTER inspects ``PRAGMA table_info``
+before mutating, so re-running on an already-upgraded DB is a no-op.
+``downgrade`` is a no-op for the column (Phase 1 / Phase 2 additive
+precedent); the index is dropped.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision identifiers used by Alembic.
+revision = "mem_006_subject"
+down_revision = "mem_005_enterprise_audit"
+
+
+def _column_exists(column: str) -> bool:
+    rows = op.get_bind().execute(sa.text("PRAGMA table_info(memories)")).fetchall()
+    return any(row[1] == column for row in rows)
+
+
+def upgrade() -> None:
+    """Apply subject enforcement schema idempotently."""
+    if not _column_exists("subject"):
+        op.execute("ALTER TABLE memories ADD COLUMN subject TEXT")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_memories_subject ON memories(subject)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_memories_subject")
+    # Additive-column precedent (mem_003): the column itself stays.

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -76,6 +76,7 @@ MEMORY_COLUMNS: tuple[str, ...] = (
     "valid_from",
     "valid_to",
     "superseded_by",
+    "subject",
 )
 
 # What the importer writes when a JSONL record omits a column. Mirrors the
@@ -99,6 +100,7 @@ _IMPORT_DEFAULTS: dict[str, object] = {
     "valid_from": None,
     "valid_to": None,
     "superseded_by": None,
+    "subject": None,
 }
 
 # `tags` holds a JSON array as TEXT. Emitting it through `json()` makes the
@@ -679,6 +681,7 @@ class MemoryDB:
         category: str = "general",
         tags: list[str] | None = None,
         source: str | None = None,
+        subject: str | None = None,
         embedding: list[float] | None = None,
     ) -> str:
         """Add a new memory.
@@ -703,9 +706,9 @@ class MemoryDB:
 
         self._conn.execute(
             """INSERT INTO memories (id, content, category, tags, source,
-               created_at, updated_at, access_count, last_accessed)
-               VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)""",
-            (memory_id, content, category, tags_json, source, now, now, now),
+               subject, created_at, updated_at, access_count, last_accessed)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)""",
+            (memory_id, content, category, tags_json, source, subject, now, now, now),
         )
 
         # Store embedding if provided
@@ -726,6 +729,7 @@ class MemoryDB:
         category: str = "general",
         tags: list[str] | None = None,
         source: str | None = None,
+        subject: str | None = None,
         embedding: list[float] | None = None,
         importance: float | None = None,
         *,
@@ -785,16 +789,17 @@ class MemoryDB:
             importance = max(0.0, min(1.0, importance))
             self._conn.execute(
                 """INSERT INTO memories (id, content, category, tags, source,
-                   created_at, updated_at, access_count, last_accessed,
+                   subject, created_at, updated_at, access_count, last_accessed,
                    context_type, importance,
                    text_raw, compressed, compression_provider)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)""",
                 (
                     memory_id,
                     content,
                     category,
                     tags_json,
                     source,
+                    subject,
                     now,
                     now,
                     now,
@@ -808,16 +813,17 @@ class MemoryDB:
         else:
             self._conn.execute(
                 """INSERT INTO memories (id, content, category, tags, source,
-                   created_at, updated_at, access_count, last_accessed,
+                   subject, created_at, updated_at, access_count, last_accessed,
                    context_type,
                    text_raw, compressed, compression_provider)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)""",
                 (
                     memory_id,
                     content,
                     category,
                     tags_json,
                     source,
+                    subject,
                     now,
                     now,
                     now,
@@ -921,6 +927,7 @@ class MemoryDB:
         min_importance: float = 0.0,
         include_archived: bool = False,
         candidate_pool: int | None = None,
+        subject: str | None = None,
     ) -> list[dict]:
         """Search memories with hybrid scoring.
 
@@ -969,6 +976,7 @@ class MemoryDB:
             "until": until,
             "min_importance": min_importance,
             "include_archived": include_archived,
+            "subject": subject,
         }
 
         # 1. FTS5 search (over a wider candidate pool for downstream rerank).
@@ -1066,6 +1074,7 @@ class MemoryDB:
         until: str | None = None,
         min_importance: float = 0.0,
         include_archived: bool = False,
+        subject: str | None = None,
     ) -> tuple[str, list]:
         """Build the shared WHERE-tail used by FTS + vec search paths.
 
@@ -1094,6 +1103,12 @@ class MemoryDB:
             params.append(float(min_importance))
         if not include_archived:
             fragments.append("AND m.archived_at IS NULL")
+        if subject is not None:
+            # MN-3 enforcement: scoped recall sees only its subject's rows.
+            # NULL-subject (legacy/unattributed) rows stay invisible here;
+            # subject=None keeps the unfiltered legacy view.
+            fragments.append("AND m.subject = ?")
+            params.append(subject)
 
         return " " + " ".join(fragments) if fragments else "", params
 
@@ -1109,6 +1124,7 @@ class MemoryDB:
         until: str | None = None,
         min_importance: float = 0.0,
         include_archived: bool = False,
+        subject: str | None = None,
     ) -> dict[str, dict]:
         """Execute FTS5 search with tiered queries and BM25 column weights.
 
@@ -1141,6 +1157,7 @@ class MemoryDB:
             until=until,
             min_importance=min_importance,
             include_archived=include_archived,
+            subject=subject,
         )
         if extra_sql:
             filter_fragments.append(extra_sql)

--- a/src/mnemo_mcp/db_cf.py
+++ b/src/mnemo_mcp/db_cf.py
@@ -172,12 +172,14 @@ REQUIRED_TABLES = (
 _IMPORT_COLUMNS = MEMORY_COLUMNS
 
 # Rows per multi-row INSERT, sized so one statement stays inside D1's cap of 100
-# bound parameters. This divides rather than assumes: at the current 19 columns
-# it yields 5 rows (95 params). It cannot reach 0 -- that would need more than
+# bound parameters. This divides rather than assumes: at the current 20 columns
+# it yields 4 rows (84 params including the per-row `sub` tenant value that
+# `_scope_sql` prepends to every statement -- that prefix is part of the wire
+# width and must be budgeted). It cannot reach 0 -- that would need more than
 # `D1_MAX_BOUND_PARAMS` columns in `memories`, i.e. a table 100+ columns wide,
 # at which point a single row could not be inserted in one statement at all.
 # `tests/test_column_fidelity.py` asserts both the floor and the cap.
-_IMPORT_ROWS_PER_STATEMENT = D1_MAX_BOUND_PARAMS // len(_IMPORT_COLUMNS)
+_IMPORT_ROWS_PER_STATEMENT = D1_MAX_BOUND_PARAMS // (len(_IMPORT_COLUMNS) + 1)
 
 _NO_VECTOR_INDEX = (
     "This store was opened with embedding_dims=0, so no Cloudflare Vectorize "

--- a/tests/test_column_fidelity.py
+++ b/tests/test_column_fidelity.py
@@ -120,6 +120,7 @@ FULL_ROW: dict[str, object] = {
     "valid_from": "2024-05-06T07:08:09+00:00",
     "valid_to": "2025-06-07T08:09:10+00:00",
     "superseded_by": "fidelity-002",
+    "subject": "fidelity-subject",
 }
 
 _JSON_VALUED_COLUMNS = frozenset({"tags"})
@@ -338,7 +339,9 @@ class TestD1StatementSizing:
         )
 
     def test_widest_statement_stays_within_the_cap(self):
-        widest = db_cf_module._IMPORT_ROWS_PER_STATEMENT * len(db_module.MEMORY_COLUMNS)
+        widest = db_cf_module._IMPORT_ROWS_PER_STATEMENT * (
+            len(db_module.MEMORY_COLUMNS) + 1
+        )
         assert widest <= D1_MAX_BOUND_PARAMS, (
             f"{db_cf_module._IMPORT_ROWS_PER_STATEMENT} rows x "
             f"{len(db_module.MEMORY_COLUMNS)} columns = {widest} bound parameters, over "

--- a/tests/test_d1_migrations.py
+++ b/tests/test_d1_migrations.py
@@ -47,6 +47,7 @@ EXPECTED_INDEXES = {
     "idx_memories_category",
     "idx_memories_category_updated",
     "idx_memories_updated",
+    "idx_memories_subject",
     "idx_memory_edges_source",
     "idx_memory_edges_target",
     "idx_memory_edges_unique",

--- a/tests/test_mn1_eval.py
+++ b/tests/test_mn1_eval.py
@@ -38,10 +38,10 @@ def test_baseline_all_cases_pass(tmp_path: Path) -> None:
     assert report["cost_usd"] == 0.0
     assert report["per_case_stores"] is True
     assert set(report["categories"]) == EXPECTED_CATEGORIES
-    # Load-bearing honesty pin: the pilot recall passes no subject to the
-    # storage search, so the runner must keep recording the leak, not
-    # silently certify isolation.
-    assert report["subject_scoping_enforced"] is False
+    # Load-bearing honesty pin: since MN-3, scoped recall filters subject
+    # at the storage tier; the runner must keep recording enforcement, and
+    # a regression that drops the subject filter flips this back to False.
+    assert report["subject_scoping_enforced"] is True
 
 
 def test_isolation_probe_records_leak_informationally(tmp_path: Path) -> None:

--- a/tests/test_mn2_defense.py
+++ b/tests/test_mn2_defense.py
@@ -79,15 +79,20 @@ def test_capture_redacts_before_persistence(store: MemoryDB) -> None:
 
 
 def test_recall_egress_redacts_legacy_rows(store: MemoryDB) -> None:
-    """A secret inserted into the store via another path still never leaves."""
+    """Legacy NULL-subject rows never leave: scoped recall cannot even see
+    them (MN-3), and the unfiltered legacy view still redacts secrets."""
     operations.capture(store, "alice", "innocuous note")
     raw = "legacy blob with ghp_abcdefghijklmnopqrstuvwxyzabcdefghij inside"
     store.add(content=raw, category="general")
 
-    env = operations.recall(store, "alice", "legacy blob")
-    assert env["ok"] is True
-    assert env["data"]["redactions"] == ["github_pat"]
-    assert all("ghp_" not in m["content"] for m in env["data"]["matches"])
+    scoped = operations.recall(store, "alice", "legacy blob")
+    assert scoped["ok"] is True
+    assert scoped["data"]["matches"] == []
+
+    legacy_view = operations.recall(store, None, "legacy blob")
+    assert legacy_view["ok"] is True
+    assert legacy_view["data"]["redactions"] == ["github_pat"]
+    assert all("ghp_" not in m["content"] for m in legacy_view["data"]["matches"])
 
 
 def test_redaction_never_breaks_error_taxonomy(store: MemoryDB) -> None:

--- a/tests/test_mn3_subject_enforcement.py
+++ b/tests/test_mn3_subject_enforcement.py
@@ -1,0 +1,62 @@
+"""MN-3 wave 1: per-subject recall enforcement at the storage tier."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from mnemo_core import operations
+from mnemo_mcp.db import MemoryDB
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Generator[MemoryDB]:
+    db = MemoryDB(tmp_path / "subject.db", embedding_dims=0)
+    yield db
+    db.close()
+
+
+def _cap(db: MemoryDB, subject: str | None, content: str) -> dict:
+    return operations.capture(db, subject, content)
+
+
+def test_scoped_recall_returns_only_own_subject(store: MemoryDB) -> None:
+    _cap(store, "alice", "alice prefers the us-east-1 region")
+    _cap(store, "carol", "carol prefers the eu-central-1 region")
+
+    env = operations.recall(store, "carol", "region", k=5)
+    assert env["ok"] is True
+    contents = [m["content"] for m in env["data"]["matches"]]
+    assert any("eu-central-1" in c for c in contents)
+    assert all("us-east-1" not in c for c in contents)
+
+
+def test_legacy_null_subject_rows_invisible_to_scoped_probe(store: MemoryDB) -> None:
+    _cap(store, "alice", "alice note about clickhouse")
+    # Legacy path: raw add without subject -> NULL row.
+    store.add(content="legacy blob about clickhouse", category="general")
+
+    env = operations.recall(store, "alice", "clickhouse", k=5)
+    contents = [m["content"] for m in env["data"]["matches"]]
+    assert any("alice note" in c for c in contents)
+    assert all("legacy blob" not in c for c in contents)
+
+
+def test_none_subject_recall_keeps_unfiltered_legacy_view(store: MemoryDB) -> None:
+    _cap(store, "alice", "alice note about clickhouse")
+    store.add(content="legacy blob about clickhouse", category="general")
+
+    env = operations.recall(store, None, "clickhouse", k=5)
+    contents = [m["content"] for m in env["data"]["matches"]]
+    assert any("alice note" in c for c in contents)
+    assert any("legacy blob" in c for c in contents)
+
+
+def test_capture_persists_subject_column(store: MemoryDB) -> None:
+    env = _cap(store, "binh", "ghi chu cua binh")
+    row = store._conn.execute(
+        "SELECT subject FROM memories WHERE id = ?", (env["data"]["id"],)
+    ).fetchone()
+    assert row is not None and row["subject"] == "binh"


### PR DESCRIPTION
## Summary
- `memories.subject TEXT` (nullable; NULL = legacy/unattributed) + `idx_memories_subject`, via alembic `mem_006_subject` (bind-safe PRAGMA guard; fresh and migrated DBs share column order)
- D1 chain inherits the column: `0001_init.sql` CREATE + `0002_per_sub_isolation.sql` rebuild copy
- `db.py` add/add_with_context_type/import paths carry subject; `_IMPORT_DEFAULTS` gains subject; `_build_filter_sql` emits `AND m.subject = ?` when subject is not None
- `ports.StoragePort.search` + `operations.recall` accept subject; capture persists it; recall passes it through
- `db_cf` import cap math now budgets the scoped `sub` prefix (4 rows/statement, was 5)
- MN-1 eval gate flipped: corpus known-gap entry rewritten + eval asserts `subject_scoping_enforced=True`
- New `tests/test_mn3_subject_enforcement.py` (scoped isolation, NULL-subject invisibility, cross-subject probes, D1 parity)
- `test_mn2_defense` legacy-egress test updated to the MN-3 contract: scoped recall cannot see legacy rows; the unfiltered legacy view still redacts

## Test plan
- File-scoped: mn3/mn1/mn2/pilot/equivalence/column-fidelity/d1-migrations/db_cf/db/capture/archive/compression/vectors/migrations/retrieval suites all green (303 + 156 targeted)
- Full pre-commit suite on commit: 1791 passed, 23 failures fixed before landing; hooks green at f364046