### PR TITLE
feat: mn4 bounded cited reflect over retrieval (dry)

### DIFF
--- a/evals/mn4_reflect_baseline.json
+++ b/evals/mn4_reflect_baseline.json
@@ -1,0 +1,19 @@
+{
+  "corpus": "mn4-eval-reflect",
+  "corpus_version": 1,
+  "deterministic": true,
+  "paid_calls": 0,
+  "cost_usd": 0.0,
+  "per_case_stores": true,
+  "total_cases": 12,
+  "passed": 12,
+  "failed_cases": [],
+  "accuracy": 1.0,
+  "latency_ms_mean": 0.826,
+  "latency_ms_p95": 1.145,
+  "known_gaps": [
+    "reflect is extractive-only in the dry tier: the answer is the best-matching stored content verbatim, never generated prose",
+    "no update/delete op: corrections remain supersede-by-new-capture",
+    "bounded-provider composition behind the Provider Spend Gate is not exercised here (dry: zero model calls by construction)"
+  ]
+}

--- a/evals/mn4_reflect_corpus.json
+++ b/evals/mn4_reflect_corpus.json
@@ -1,0 +1,126 @@
+{
+  "name": "mn4-eval-reflect",
+  "version": 1,
+  "known_gaps": [
+    "reflect is extractive-only in the dry tier: the answer is the best-matching stored content verbatim, never generated prose",
+    "no update/delete op: corrections remain supersede-by-new-capture",
+    "bounded-provider composition behind the Provider Spend Gate is not exercised here (dry: zero model calls by construction)"
+  ],
+  "cases": [
+    {
+      "id": "mn4-cite-en-deploy",
+      "lang": "en",
+      "category": "citation_answer",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "deploy checklist for pilot", "tags": ["ops"]}}
+      ],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "deploy checklist", "k": 5}},
+      "expect": {"type": "reflect_answer_contains", "needle": "deploy checklist for pilot"}
+    },
+    {
+      "id": "mn4-cite-vi-meeting",
+      "lang": "vi",
+      "category": "citation_answer",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "ghi chú họp ngày mai lúc 9 giờ với nhóm pilot"}}
+      ],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "họp ngày mai", "k": 5}},
+      "expect": {"type": "reflect_answer_contains", "needle": "họp ngày mai lúc 9 giờ"}
+    },
+    {
+      "id": "mn4-cite-picks-best-match",
+      "lang": "en",
+      "category": "citation_answer",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "random note about gardening"}},
+        {"op": "capture", "subject": "alice", "args": {"content": "oncall rotation: alice covers monday"}}
+      ],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "oncall rotation monday", "k": 5}},
+      "expect": {"type": "reflect_answer_contains", "needle": "oncall rotation: alice covers monday"}
+    },
+    {
+      "id": "mn4-abstain-empty-store",
+      "lang": "en",
+      "category": "abstention",
+      "setup": [],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "anything at all", "k": 5}},
+      "expect": {"type": "reflect_abstains", "reason": "no_retrieval_support"}
+    },
+    {
+      "id": "mn4-abstain-no-lexical-overlap",
+      "lang": "vi",
+      "category": "abstention",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "ghi chú họp ngày mai"}}
+      ],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "xyzzy unrelated query", "k": 5}},
+      "expect": {"type": "reflect_abstains", "reason": "no_retrieval_support"}
+    },
+    {
+      "id": "mn4-scope-bob-abstains",
+      "lang": "en",
+      "category": "subject_scope",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "alice deploy checklist"}}
+      ],
+      "probe": {"op": "reflect", "subject": "bob", "args": {"query": "deploy checklist", "k": 5}},
+      "expect": {"type": "reflect_abstains", "reason": "no_retrieval_support"}
+    },
+    {
+      "id": "mn4-scope-alice-answers",
+      "lang": "en",
+      "category": "subject_scope",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "alice deploy checklist"}}
+      ],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "deploy checklist", "k": 5}},
+      "expect": {"type": "reflect_answer_contains", "needle": "alice deploy checklist"}
+    },
+    {
+      "id": "mn4-scope-legacy-invisible-to-scoped",
+      "lang": "en",
+      "category": "subject_scope",
+      "setup": [
+        {"op": "capture", "subject": null, "args": {"content": "legacy blob without subject"}}
+      ],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "legacy blob", "k": 5}},
+      "expect": {"type": "reflect_abstains", "reason": "no_retrieval_support"}
+    },
+    {
+      "id": "mn4-scope-null-sees-legacy",
+      "lang": "en",
+      "category": "subject_scope",
+      "setup": [
+        {"op": "capture", "subject": null, "args": {"content": "legacy blob without subject"}}
+      ],
+      "probe": {"op": "reflect", "subject": null, "args": {"query": "legacy blob", "k": 5}},
+      "expect": {"type": "reflect_answer_contains", "needle": "legacy blob without subject"}
+    },
+    {
+      "id": "mn4-redaction-secret-masked",
+      "lang": "en",
+      "category": "redaction_egress",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "oncall email alice@example.com handles incidents"}}
+      ],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "oncall email", "k": 5}},
+      "expect": {"type": "reflect_answer_contains", "needle": "[REDACTED:email]"}
+    },
+    {
+      "id": "mn4-validation-empty-query",
+      "lang": "en",
+      "category": "validation",
+      "setup": [],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "   "}},
+      "expect": {"type": "error_code", "code": "VALIDATION"}
+    },
+    {
+      "id": "mn4-validation-k-below-one",
+      "lang": "en",
+      "category": "validation",
+      "setup": [],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "query", "k": 0}},
+      "expect": {"type": "error_code", "code": "VALIDATION"}
+    }
+  ]
+}

--- a/evals/run_mn4_reflect.py
+++ b/evals/run_mn4_reflect.py
@@ -1,0 +1,133 @@
+"""MN-4 eval runner: bounded cited reflect (offline, deterministic, dry).
+
+Mirrors the MN-1 runner contract: one fresh DB per case; scoring uses
+deterministic envelope outcomes only (exact substring membership in the
+extractive answer, abstention flags + reasons, error-taxonomy codes) —
+never prose similarity. Every reflect envelope is additionally asserted
+bounded: ``cost.model_calls == 0`` (dry tier — no paid calls by
+construction).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from mnemo_core import operations
+from mnemo_mcp.db import MemoryDB
+
+CORPUS_PATH = Path(__file__).with_name("mn4_reflect_corpus.json")
+REPORT_PATH = Path(__file__).with_name("mn4_reflect_baseline.json")
+
+_ZERO_COST = {"model_calls": 0, "prompt_tokens": 0, "completion_tokens": 0}
+
+
+def _run_op(db: MemoryDB, op: dict[str, Any]) -> dict[str, Any]:
+    name, subject, args = op["op"], op["subject"], dict(op.get("args", {}))
+    if name == "capture":
+        return operations.capture(
+            db,
+            subject,
+            args["content"],
+            tags=args.get("tags"),
+            category=args.get("category", "general"),
+            source=args.get("source"),
+        )
+    if name == "reflect":
+        return operations.reflect(db, subject, args["query"], k=args.get("k", 5))
+    raise ValueError(f"unknown op: {name}")
+
+
+def _check(expect: dict[str, Any], envelope: dict[str, Any]) -> tuple[bool, str | None]:
+    etype = expect["type"]
+    if etype == "reflect_answer_contains":
+        if not envelope.get("ok"):
+            return False, "envelope not ok"
+        data = envelope["data"]
+        if data["abstained"] is not False:
+            return False, "unexpectedly abstained"
+        if data["cost"] != _ZERO_COST:
+            return False, "non-zero cost receipt in dry tier"
+        if not data["citations"]:
+            return False, "no citations"
+        if data["answer"] not in [c["content"] for c in data["citations"]]:
+            return False, "answer is not a citation (extractive contract)"
+        return expect["needle"] in (data["answer"] or ""), None
+    if etype == "reflect_abstains":
+        if not envelope.get("ok"):
+            return False, "envelope not ok"
+        data = envelope["data"]
+        if data["abstained"] is not True:
+            return False, "expected abstention"
+        if data["reason"] != expect["reason"]:
+            return False, f"reason {data['reason']!r} != {expect['reason']!r}"
+        if data["answer"] is not None or data["citations"]:
+            return False, "abstained envelope must carry no answer/citations"
+        if data["cost"] != _ZERO_COST:
+            return False, "non-zero cost receipt in dry tier"
+        return True, None
+    if etype == "error_code":
+        return (
+            not envelope.get("ok")
+            and envelope.get("error", {}).get("code") == expect["code"]
+        ), None
+    raise ValueError(f"unknown expectation: {etype}")
+
+
+def run_eval(run_dir: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    for case in corpus["cases"]:
+        db = MemoryDB(run_dir / f"{case['id']}.db", embedding_dims=0)
+        try:
+            for step in case["setup"]:
+                env = _run_op(db, step)
+                if not env.get("ok"):
+                    raise RuntimeError(f"{case['id']}: setup failed: {env}")
+            t0 = time.perf_counter()
+            envelope = _run_op(db, case["probe"])
+            latency_ms = (time.perf_counter() - t0) * 1000.0
+        finally:
+            db.close()
+        passed, why = _check(case["expect"], envelope)
+        row: dict[str, Any] = {
+            "id": case["id"],
+            "lang": case["lang"],
+            "passed": passed,
+            "latency_ms": latency_ms,
+        }
+        if why:
+            row["why"] = why
+        rows.append(row)
+    latencies = [r["latency_ms"] for r in rows]
+    failed = [r["id"] for r in rows if not r["passed"]]
+    report: dict[str, Any] = {
+        "corpus": corpus["name"],
+        "corpus_version": corpus["version"],
+        "deterministic": True,
+        "paid_calls": 0,
+        "cost_usd": 0.0,
+        "per_case_stores": True,
+        "total_cases": len(rows),
+        "passed": len(rows) - len(failed),
+        "failed_cases": failed,
+        "accuracy": (len(rows) - len(failed)) / len(rows) if rows else 0.0,
+        "latency_ms_mean": round(sum(latencies) / len(latencies), 3),
+        "latency_ms_p95": round(sorted(latencies)[int(0.95 * (len(latencies) - 1))], 3),
+        "known_gaps": corpus["known_gaps"],
+    }
+    return report
+
+
+def main() -> int:  # pragma: no cover
+    report = run_eval(Path(__file__).parent / "mn4_run")
+    REPORT_PATH.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0 if report["accuracy"] == 1.0 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/mnemo_cli/__main__.py
+++ b/src/mnemo_cli/__main__.py
@@ -23,7 +23,7 @@ def _serialize(envelope: dict) -> str:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="mnemo-pilot",
-        description="Mnemo pilot CLI (capture/recall/fetch) over the shared domain core",
+        description="Mnemo pilot CLI (capture/recall/reflect/fetch) over the shared domain core",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 

--- a/src/mnemo_cli/__main__.py
+++ b/src/mnemo_cli/__main__.py
@@ -43,6 +43,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_recall.add_argument("query")
     p_recall.add_argument("--k", type=int, default=5)
 
+    p_reflect = sub.add_parser("reflect", help="Bounded cited reflect over retrieval")
+    add_common(p_reflect)
+    p_reflect.add_argument("query")
+    p_reflect.add_argument("--k", type=int, default=5)
+
     p_fetch = sub.add_parser("fetch", help="Fetch one memory by id")
     add_common(p_fetch)
     p_fetch.add_argument("memory_id")
@@ -67,6 +72,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         elif args.command == "recall":
             envelope = operations.recall(store, args.subject, args.query, k=args.k)
+        elif args.command == "reflect":
+            envelope = operations.reflect(store, args.subject, args.query, k=args.k)
         else:
             envelope = operations.fetch(store, args.subject, args.memory_id)
     finally:

--- a/src/mnemo_core/operations.py
+++ b/src/mnemo_core/operations.py
@@ -108,6 +108,72 @@ def fetch(
     return results.ok({"subject": subject, "memory": memory, "redactions": kinds})
 
 
+_MAX_REFLECT_K = 10
+
+
+def reflect(
+    store: StoragePort,
+    subject: str | None,
+    query: str,
+    k: int = 5,
+) -> dict[str, Any]:
+    """Bounded cited reflect (P4, dry).
+
+    The answer is composed ONLY from retrieval results (extractive: the best
+    match's redacted content is returned verbatim as ``answer``). When
+    retrieval has no support the envelope abstains explicitly. Zero model
+    calls are made, and the cost receipt is always present so the caller can
+    audit boundedness. Reflect never writes back.
+    """
+    if not query or not query.strip():
+        return results.err(results.VALIDATION, "query is required")
+    if k < 1:
+        return results.err(results.VALIDATION, "k must be >= 1")
+    try:
+        rows = store.search(
+            query.strip(), limit=min(k, _MAX_REFLECT_K), subject=subject
+        )
+    except sqlite3.Error as exc:
+        return results.err(results.STORAGE, f"reflect retrieval failed: {exc}")
+    except Exception as exc:  # noqa: BLE001 - taxonomy boundary
+        return results.err(results.INTERNAL, f"unexpected failure: {exc}")
+    citations, redactions = _redact_rows(
+        [
+            {
+                "id": row.get("id"),
+                "subject": row.get("subject"),
+                "content": row.get("content"),
+                "score": row.get("score"),
+            }
+            for row in rows
+        ]
+    )
+    receipt = {"model_calls": 0, "prompt_tokens": 0, "completion_tokens": 0}
+    if not citations:
+        return results.ok(
+            {
+                "subject": subject,
+                "answer": None,
+                "abstained": True,
+                "reason": "no_retrieval_support",
+                "citations": [],
+                "redactions": [],
+                "cost": receipt,
+            }
+        )
+    best = citations[0]
+    return results.ok(
+        {
+            "subject": subject,
+            "answer": best["content"],
+            "abstained": False,
+            "citations": citations,
+            "redactions": redactions,
+            "cost": receipt,
+        }
+    )
+
+
 def _redact_row(row: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     """Egress defense: redact stored content before it leaves the core."""
     content = row.get("content") if isinstance(row, dict) else None

--- a/src/mnemo_mcp/pilot_tools.py
+++ b/src/mnemo_mcp/pilot_tools.py
@@ -35,3 +35,8 @@ def pilot_recall(db: MemoryDB, subject: str | None, args: dict[str, Any]) -> dic
 def pilot_fetch(db: MemoryDB, subject: str | None, args: dict[str, Any]) -> dict:
     """MCP tool ``pilot_fetch``: args dict in, envelope out."""
     return operations.fetch(db, subject, args.get("memory_id", ""))
+
+
+def pilot_reflect(db: MemoryDB, subject: str | None, args: dict[str, Any]) -> dict:
+    """MCP tool ``pilot_reflect``: args dict in, envelope out."""
+    return operations.reflect(db, subject, args.get("query", ""), k=args.get("k", 5))

--- a/tests/test_mn4_eval.py
+++ b/tests/test_mn4_eval.py
@@ -29,10 +29,10 @@ def test_corpus_is_wellformed() -> None:
 
 def test_baseline_all_cases_pass(tmp_path: Path) -> None:
     report = run_eval(tmp_path / "run")
-    assert report["total_cases"] >= 12
-    assert report["failed_cases"] == [], f"failed: {report['failed_cases']}"
-    assert report["per_case_stores"] is True
+    assert report["accuracy"] == 1.0
+    assert report["paid_calls"] == 0
     assert report["cost_usd"] == 0.0
+    assert report["per_case_stores"] is True
 
 
 def test_determinism_across_runs(tmp_path: Path) -> None:

--- a/tests/test_mn4_eval.py
+++ b/tests/test_mn4_eval.py
@@ -1,0 +1,66 @@
+"""MN-4 eval: reflect corpus must pass fully against the dry pilot core."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from evals.run_mn4_reflect import CORPUS_PATH, REPORT_PATH, run_eval
+
+EXPECTED_CATEGORIES = {
+    "citation_answer",
+    "abstention",
+    "subject_scope",
+    "redaction_egress",
+    "validation",
+}
+
+
+def test_corpus_is_wellformed() -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    ids = [c["id"] for c in corpus["cases"]]
+    assert len(ids) == len(set(ids)), "duplicate case ids"
+    assert {c["category"] for c in corpus["cases"]} == EXPECTED_CATEGORIES
+    langs = {c["lang"] for c in corpus["cases"]}
+    assert langs == {"en", "vi"}
+    gaps = " ".join(corpus["known_gaps"])
+    assert "extractive-only" in gaps and "Spend Gate" in gaps
+
+
+def test_baseline_all_cases_pass(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "run")
+    assert report["total_cases"] >= 12
+    assert report["failed_cases"] == [], f"failed: {report['failed_cases']}"
+    assert report["per_case_stores"] is True
+    assert report["cost_usd"] == 0.0
+
+
+def test_determinism_across_runs(tmp_path: Path) -> None:
+    first = run_eval(tmp_path / "a")
+    second = run_eval(tmp_path / "b")
+    assert first["accuracy"] == second["accuracy"]
+    assert first["passed"] == second["passed"]
+    assert first["failed_cases"] == second["failed_cases"]
+
+
+def test_scoring_detects_failure_by_tampering(tmp_path: Path) -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    for case in corpus["cases"]:
+        if case["expect"]["type"] == "reflect_answer_contains":
+            case["expect"]["needle"] = "no-such-needle-xyz"
+            break
+    tampered = tmp_path / "tampered.json"
+    tampered.write_text(json.dumps(corpus), encoding="utf-8")
+    report = run_eval(tmp_path / "run", corpus_path=tampered)
+    assert report["accuracy"] < 1.0
+    assert len(report["failed_cases"]) == 1
+
+
+def test_main_report_written(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "run")
+    out = tmp_path / "mn4_reflect_baseline.json"
+    out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    saved = json.loads(out.read_text(encoding="utf-8"))
+    assert saved["deterministic"] is True
+    assert saved["known_gaps"]
+    assert REPORT_PATH.name == "mn4_reflect_baseline.json"

--- a/tests/test_mn4_reflect.py
+++ b/tests/test_mn4_reflect.py
@@ -1,0 +1,93 @@
+"""MN-4: bounded cited reflect unit tests (dry — zero model calls)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from mnemo_core import operations, results
+from mnemo_mcp.db import MemoryDB
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Iterator[MemoryDB]:
+    db = MemoryDB(tmp_path / "reflect.db", embedding_dims=0)
+    yield db
+    db.close()
+
+
+def test_reflect_answers_with_citation_only(store: MemoryDB) -> None:
+    operations.capture(store, "alice", "deploy checklist for pilot")
+    envelope = operations.reflect(store, "alice", "deploy checklist")
+    assert envelope["ok"] is True
+    data = envelope["data"]
+    assert data["abstained"] is False
+    assert data["citations"], "reflect must cite retrieval results"
+    assert data["answer"] == data["citations"][0]["content"]
+    # Extractive contract: the answer is a stored content verbatim.
+    stored = operations.recall(store, "alice", "deploy")["data"]["matches"][0][
+        "content"
+    ]
+    assert data["answer"] == stored
+    assert data["cost"] == {
+        "model_calls": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+    }
+
+
+def test_reflect_abstains_without_retrieval_support(store: MemoryDB) -> None:
+    envelope = operations.reflect(store, "alice", "unheard question")
+    assert envelope["ok"] is True
+    data = envelope["data"]
+    assert data["abstained"] is True
+    assert data["reason"] == "no_retrieval_support"
+    assert data["answer"] is None
+    assert data["citations"] == []
+    assert data["cost"]["model_calls"] == 0
+
+
+def test_reflect_never_writes_back(store: MemoryDB) -> None:
+    operations.capture(store, "alice", "deploy checklist for pilot")
+    before = operations.recall(store, "alice", "deploy", k=10)["data"]["matches"]
+    operations.reflect(store, "alice", "deploy checklist")
+    after = operations.recall(store, "alice", "deploy", k=10)["data"]["matches"]
+    assert len(after) == len(before)
+    assert [m["id"] for m in after] == [m["id"] for m in before]
+
+
+def test_reflect_validates_inputs(store: MemoryDB) -> None:
+    empty_query = operations.reflect(store, "alice", "   ")
+    assert empty_query["error"]["code"] == results.VALIDATION
+    bad_k = operations.reflect(store, "alice", "query", k=0)
+    assert bad_k["error"]["code"] == results.VALIDATION
+
+
+def test_reflect_k_is_clamped(store: MemoryDB) -> None:
+    for i in range(15):
+        operations.capture(store, "alice", f"note number {i} about deploy")
+    envelope = operations.reflect(store, "alice", "deploy", k=50)
+    assert envelope["ok"] is True
+    assert len(envelope["data"]["citations"]) <= 10
+
+
+def test_reflect_never_emits_raw_secret(store: MemoryDB) -> None:
+    token = "ghp_" + "a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8"
+    captured = operations.capture(store, "alice", f"token {token} leaked")
+    assert captured["data"]["redactions"] == ["github_pat"]
+    envelope = operations.reflect(store, "alice", "token")
+    assert envelope["ok"] is True
+    data = envelope["data"]
+    assert "ghp_" not in (data["answer"] or "")
+    assert all("ghp_" not in c["content"] for c in data["citations"])
+
+
+def test_reflect_respects_subject_scope(store: MemoryDB) -> None:
+    operations.capture(store, "alice", "alice deploy checklist")
+    bob = operations.reflect(store, "bob", "deploy checklist")
+    assert bob["ok"] is True
+    assert bob["data"]["abstained"] is True
+    alice = operations.reflect(store, "alice", "deploy checklist")
+    assert alice["data"]["abstained"] is False

--- a/tests/test_mnemo_pilot_equivalence.py
+++ b/tests/test_mnemo_pilot_equivalence.py
@@ -80,12 +80,22 @@ SCENARIOS: list[tuple[str, dict[str, Any]]] = [
     ("recall", {"query": "   "}),  # VALIDATION
     ("fetch", {"memory_id": "deadbeef"}),  # NOT_FOUND
     ("fetch", {"memory_id": ""}),  # VALIDATION
+    ("reflect", {"query": "   "}),  # VALIDATION
+    ("reflect", {"query": "deploy checklist"}),  # abstention on empty store
+    (
+        "reflect",
+        {
+            "query": "deploy checklist",
+            "seed": [{"content": "deploy checklist for pilot", "tags": ["ops"]}],
+        },
+    ),
 ]
 
 _HANDLERS = {
     "capture": pilot_tools.pilot_capture,
     "recall": pilot_tools.pilot_recall,
     "fetch": pilot_tools.pilot_fetch,
+    "reflect": pilot_tools.pilot_reflect,
 }
 
 
@@ -99,6 +109,19 @@ def test_cli_and_mcp_envelopes_are_byte_equal(
         cli_db = tmp_path / f"cli-{i}.db"
         mcp_store = MemoryDB(tmp_path / f"mcp-{i}.db", embedding_dims=0)
         cli_args: list[str] = ["--db", str(cli_db), "--subject", "alice"]
+        for seed in args.get("seed", []):
+            seed_args = [
+                "capture",
+                "--db",
+                str(cli_db),
+                "--subject",
+                "alice",
+                seed["content"],
+            ]
+            seed_out, seed_code = _run_cli(seed_args, capsys)
+            assert seed_code == 0, seed_out
+            mcp_seed = pilot_tools.pilot_capture(mcp_store, "alice", seed)
+            assert mcp_seed["ok"] is True, mcp_seed
         if op == "capture":
             cli_args += [args["content"]]
             if "tags" in args:
@@ -106,6 +129,8 @@ def test_cli_and_mcp_envelopes_are_byte_equal(
             if "category" in args and args["category"] != "general":
                 cli_args += ["--category", args["category"]]
         elif op == "recall":
+            cli_args += [args["query"], "--k", str(args.get("k", 5))]
+        elif op == "reflect":
             cli_args += [args["query"], "--k", str(args.get("k", 5))]
         else:
             cli_args += [args["memory_id"]]
@@ -238,6 +263,35 @@ def test_subject_isolation_envelopes_are_byte_equal_both_surfaces(
         else:
             assert cli_env["error"]["code"] == want_code
             assert mcp_env["error"]["code"] == want_code
+
+    # MN-4: reflect obeys the same subject contract on both surfaces.
+    reflect_cases = [
+        ("alice", {"query": "deploy checklist", "k": 5}, False),
+        ("bob", {"query": "deploy checklist", "k": 5}, True),
+        ("alice", {"query": "legacy blob", "k": 5}, True),
+        (None, {"query": "legacy blob", "k": 5}, False),
+    ]
+    for rj, (subject, mcp_args, want_abstain) in enumerate(reflect_cases):
+        cli_args = ["reflect", "--db", str(cli_db)]
+        if subject is not None:
+            cli_args += ["--subject", subject]
+        cli_args += [str(mcp_args["query"]), "--k", str(mcp_args["k"])]
+        cli_out, cli_code = _run_cli(cli_args, capsys)
+        cli_env = json.loads(cli_out)
+        mcp_env = _HANDLERS["reflect"](mcp_store, subject, mcp_args)
+        assert _canonical(cli_env) == _canonical(mcp_env), f"reflect case {rj}"
+        assert (cli_env["ok"] is True) == (cli_code == 0)
+        for env in (cli_env, mcp_env):
+            assert env["data"]["abstained"] is want_abstain
+            assert env["data"]["cost"] == {
+                "model_calls": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+            }
+            if not want_abstain:
+                assert env["data"]["answer"] in [
+                    c["content"] for c in env["data"]["citations"]
+                ]
     mcp_store.close()
 
 


### PR DESCRIPTION
MN-4 of the mnemo pilot (P4, dry tier). operations.reflect composes the answer ONLY from retrieval citations (extractive: best match verbatim), abstains explicitly with reason when retrieval has no support, always reports a zero cost receipt (no model calls by construction), and never writes back. Surfaces: CLI reflect subcommand + pilot_reflect MCP-shaped handler. Equivalence gate extended (reflect VALIDATION/abstention/seeded answer + subject-isolation cases both surfaces). MN-4 eval: 12-case deterministic corpus, accuracy 1.0, paid_calls 0. Also fixes a regression where adding the reflect subcommand dropped recall's --k argument.