### PR TITLE
feat: mn5 standing questions - materialized pages with staleness (dry)

### DIFF
--- a/evals/mn5_standing_baseline.json
+++ b/evals/mn5_standing_baseline.json
@@ -1,0 +1,19 @@
+{
+  "corpus": "mn5-eval-standing",
+  "corpus_version": 1,
+  "deterministic": true,
+  "paid_calls": 0,
+  "cost_usd": 0.0,
+  "per_case_stores": true,
+  "total_cases": 8,
+  "passed": 8,
+  "failed_cases": [],
+  "accuracy": 1.0,
+  "latency_ms_mean": 0.744,
+  "latency_ms_p95": 1.082,
+  "known_gaps": [
+    "pages are materialized from the dry extractive reflect tier; no generated prose answers",
+    "staleness is computed on read against pinned source hashes; there is no scheduled re-validation",
+    "the pilot tier has no delete op: invalidation is a tombstone page and supersede is newest-wins"
+  ]
+}

--- a/evals/mn5_standing_corpus.json
+++ b/evals/mn5_standing_corpus.json
@@ -1,0 +1,97 @@
+{
+  "name": "mn5-eval-standing",
+  "version": 1,
+  "known_gaps": [
+    "pages are materialized from the dry extractive reflect tier; no generated prose answers",
+    "staleness is computed on read against pinned source hashes; there is no scheduled re-validation",
+    "the pilot tier has no delete op: invalidation is a tombstone page and supersede is newest-wins"
+  ],
+  "cases": [
+    {
+      "id": "mn5-materialize-and-read-fresh",
+      "lang": "en",
+      "category": "materialize_read",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "deploy checklist for pilot"}},
+        {"op": "standing_refresh", "subject": "alice", "args": {"key": "deploy-page", "question": "deploy checklist"}}
+      ],
+      "probe": {"op": "standing_read", "subject": "alice", "args": {"key": "deploy-page"}},
+      "expect": {"type": "standing_fresh", "answer_contains": "deploy checklist"}
+    },
+    {
+      "id": "mn5-materialize-vi",
+      "lang": "vi",
+      "category": "materialize_read",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "ghi chú họp ngày mai lúc 9 giờ"}},
+        {"op": "standing_refresh", "subject": "alice", "args": {"key": "hop-page", "question": "họp ngày mai"}}
+      ],
+      "probe": {"op": "standing_read", "subject": "alice", "args": {"key": "hop-page"}},
+      "expect": {"type": "standing_fresh", "answer_contains": "họp ngày mai"}
+    },
+    {
+      "id": "mn5-read-missing-page",
+      "lang": "en",
+      "category": "abstention",
+      "setup": [],
+      "probe": {"op": "standing_read", "subject": "alice", "args": {"key": "ghost"}},
+      "expect": {"type": "error_code", "code": "NOT_FOUND"}
+    },
+    {
+      "id": "mn5-scope-bob-cannot-read-alice-page",
+      "lang": "en",
+      "category": "subject_scope",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "alice deploy checklist"}},
+        {"op": "standing_refresh", "subject": "alice", "args": {"key": "dp", "question": "deploy checklist"}}
+      ],
+      "probe": {"op": "standing_read", "subject": "bob", "args": {"key": "dp"}},
+      "expect": {"type": "error_code", "code": "NOT_FOUND"}
+    },
+    {
+      "id": "mn5-source-missing-verdicts-stale",
+      "lang": "en",
+      "category": "staleness",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "oncall rotation alice monday"}},
+        {"op": "standing_refresh", "subject": "alice", "args": {"key": "oncall-page", "question": "oncall rotation"}},
+        {"op": "hard_delete_sources", "subject": "alice", "args": {}}
+      ],
+      "probe": {"op": "standing_read", "subject": "alice", "args": {"key": "oncall-page"}},
+      "expect": {"type": "standing_stale", "reason": "stale:source_missing"}
+    },
+    {
+      "id": "mn5-tombstone-invalidates",
+      "lang": "en",
+      "category": "invalidation",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "deploy checklist for pilot"}},
+        {"op": "standing_refresh", "subject": "alice", "args": {"key": "dp", "question": "deploy checklist"}},
+        {"op": "standing_invalidate", "subject": "alice", "args": {"key": "dp", "question": "deploy checklist"}}
+      ],
+      "probe": {"op": "standing_read", "subject": "alice", "args": {"key": "dp"}},
+      "expect": {"type": "standing_tombstone"}
+    },
+    {
+      "id": "mn5-supersede-newest-wins",
+      "lang": "en",
+      "category": "invalidation",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "deploy checklist v1"}},
+        {"op": "capture", "subject": "alice", "args": {"content": "deploy checklist v2 rollout"}},
+        {"op": "standing_refresh", "subject": "alice", "args": {"key": "dp", "question": "deploy checklist v1"}},
+        {"op": "standing_refresh", "subject": "alice", "args": {"key": "dp", "question": "checklist v2 rollout"}}
+      ],
+      "probe": {"op": "standing_read", "subject": "alice", "args": {"key": "dp"}},
+      "expect": {"type": "standing_fresh", "answer_contains": "deploy checklist v2 rollout"}
+    },
+    {
+      "id": "mn5-validation-empty-key",
+      "lang": "en",
+      "category": "validation",
+      "setup": [],
+      "probe": {"op": "standing_refresh", "subject": "alice", "args": {"key": "  ", "question": "q"}},
+      "expect": {"type": "error_code", "code": "VALIDATION"}
+    }
+  ]
+}

--- a/evals/run_mn5_standing.py
+++ b/evals/run_mn5_standing.py
@@ -1,0 +1,145 @@
+"""MN-5 eval runner: standing questions / knowledge pages (dry).
+
+Mirrors the MN-1/MN-4 runner contracts: one fresh DB per case;
+deterministic scoring only (exact substring in the materialized answer,
+staleness verdicts, error-taxonomy codes). The ``hard_delete_sources``
+setup op removes non-standing rows directly at the SQLite layer to
+exercise the missing-source verdict (the pilot tier itself has no
+delete op). Every read is bounded by construction: zero model calls.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from mnemo_core import operations, standing
+from mnemo_mcp.db import MemoryDB
+
+CORPUS_PATH = Path(__file__).with_name("mn5_standing_corpus.json")
+REPORT_PATH = Path(__file__).with_name("mn5_standing_baseline.json")
+
+_ZERO_COST = {"model_calls": 0, "prompt_tokens": 0, "completion_tokens": 0}
+
+
+def _run_op(db: MemoryDB, op: dict[str, Any]) -> dict[str, Any]:
+    name, subject, args = op["op"], op["subject"], dict(op.get("args", {}))
+    if name == "capture":
+        return operations.capture(
+            db,
+            subject,
+            args["content"],
+            tags=args.get("tags"),
+            category=args.get("category", "general"),
+            source=args.get("source"),
+        )
+    if name == "standing_refresh":
+        return standing.standing_refresh(
+            db, subject, args["key"], args["question"], k=args.get("k", 5)
+        )
+    if name == "standing_invalidate":
+        return standing.standing_invalidate(db, subject, args["key"])
+    if name == "standing_read":
+        return standing.standing_read(db, subject, args["key"])
+    if name == "hard_delete_sources":
+        conn = sqlite3.connect(db._db_path)  # noqa: SLF001 - eval-only backdoor
+        try:
+            conn.execute("DELETE FROM memories WHERE category != '_standing'")
+            conn.commit()
+        finally:
+            conn.close()
+        return {"ok": True, "data": {}}
+    raise ValueError(f"unknown op: {name}")
+
+
+def _check(expect: dict[str, Any], envelope: dict[str, Any]) -> tuple[bool, str | None]:
+    etype = expect["type"]
+    if etype == "standing_fresh":
+        if not envelope.get("ok"):
+            return False, "envelope not ok"
+        data = envelope["data"]
+        if data.get("tombstone"):
+            return False, "unexpected tombstone"
+        if data.get("staleness") != "fresh":
+            return False, f"staleness {data.get('staleness')!r} != fresh"
+        if data.get("cost") != _ZERO_COST:
+            return False, "non-zero cost receipt"
+        return expect["answer_contains"] in (data.get("answer") or ""), None
+    if etype == "standing_stale":
+        data = envelope.get("data", {})
+        return (
+            envelope.get("ok") is True and data.get("staleness") == expect["reason"]
+        ), None
+    if etype == "standing_tombstone":
+        data = envelope.get("data", {})
+        return (
+            envelope.get("ok") is True
+            and data.get("tombstone") is True
+            and data.get("staleness") == "invalidated"
+            and data.get("cost") == _ZERO_COST
+        ), None
+    if etype == "error_code":
+        return (
+            not envelope.get("ok")
+            and envelope.get("error", {}).get("code") == expect["code"]
+        ), None
+    raise ValueError(f"unknown expectation: {etype}")
+
+
+def run_eval(run_dir: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    for case in corpus["cases"]:
+        db = MemoryDB(run_dir / f"{case['id']}.db", embedding_dims=0)
+        try:
+            for step in case["setup"]:
+                env = _run_op(db, step)
+                if not env.get("ok"):
+                    raise RuntimeError(f"{case['id']}: setup failed: {env}")
+            t0 = time.perf_counter()
+            envelope = _run_op(db, case["probe"])
+            latency_ms = (time.perf_counter() - t0) * 1000.0
+        finally:
+            db.close()
+        passed, why = _check(case["expect"], envelope)
+        row: dict[str, Any] = {
+            "id": case["id"],
+            "lang": case["lang"],
+            "passed": passed,
+            "latency_ms": latency_ms,
+        }
+        if why:
+            row["why"] = why
+        rows.append(row)
+    latencies = [r["latency_ms"] for r in rows]
+    failed = [r["id"] for r in rows if not r["passed"]]
+    return {
+        "corpus": corpus["name"],
+        "corpus_version": corpus["version"],
+        "deterministic": True,
+        "paid_calls": 0,
+        "cost_usd": 0.0,
+        "per_case_stores": True,
+        "total_cases": len(rows),
+        "passed": len(rows) - len(failed),
+        "failed_cases": failed,
+        "accuracy": (len(rows) - len(failed)) / len(rows) if rows else 0.0,
+        "latency_ms_mean": round(sum(latencies) / len(latencies), 3),
+        "latency_ms_p95": round(sorted(latencies)[int(0.95 * (len(latencies) - 1))], 3),
+        "known_gaps": corpus["known_gaps"],
+    }
+
+
+def main() -> int:  # pragma: no cover
+    report = run_eval(Path(__file__).parent / "mn5_run")
+    REPORT_PATH.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0 if report["accuracy"] == 1.0 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/mnemo_cli/__main__.py
+++ b/src/mnemo_cli/__main__.py
@@ -12,7 +12,7 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-from mnemo_core import operations, results
+from mnemo_core import operations, results, standing
 from mnemo_mcp.db import MemoryDB
 
 
@@ -52,6 +52,27 @@ def _build_parser() -> argparse.ArgumentParser:
     add_common(p_fetch)
     p_fetch.add_argument("memory_id")
 
+    p_sref = sub.add_parser(
+        "standing-refresh", help="Materialize a standing page via reflect"
+    )
+    add_common(p_sref)
+    p_sref.add_argument("key")
+    p_sref.add_argument("question")
+    p_sref.add_argument("--k", type=int, default=5)
+
+    p_sread = sub.add_parser(
+        "standing-read", help="Cheap read of a standing page with staleness"
+    )
+    add_common(p_sread)
+    p_sread.add_argument("key")
+
+    p_sinv = sub.add_parser(
+        "standing-invalidate", help="Materialize a tombstone standing page"
+    )
+    add_common(p_sinv)
+    p_sinv.add_argument("key")
+    p_sinv.add_argument("--question", default="")
+
     return parser
 
 
@@ -74,6 +95,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             envelope = operations.recall(store, args.subject, args.query, k=args.k)
         elif args.command == "reflect":
             envelope = operations.reflect(store, args.subject, args.query, k=args.k)
+        elif args.command == "standing-refresh":
+            envelope = standing.standing_refresh(
+                store, args.subject, args.key, args.question, k=args.k
+            )
+        elif args.command == "standing-read":
+            envelope = standing.standing_read(store, args.subject, args.key)
+        elif args.command == "standing-invalidate":
+            envelope = standing.standing_invalidate(
+                store,
+                args.subject,
+                args.key,
+                question=args.question,
+            )
         else:
             envelope = operations.fetch(store, args.subject, args.memory_id)
     finally:

--- a/src/mnemo_core/standing.py
+++ b/src/mnemo_core/standing.py
@@ -1,0 +1,223 @@
+"""Standing questions / knowledge pages (MN-5 / P5, dry).
+
+A standing page materializes a reflect answer together with the exact
+source versions it was built from, so a later read is cheap (no search,
+no recompute) and can verdict staleness deterministically.
+
+Storage mapping (no schema migration): a page is a memory row with
+``category="_standing"`` whose content is a JSON document. The pilot
+tier has no update/delete, so pages follow the corpus-wide
+newest-wins supersede semantics: the page with the highest id for
+(subject, key) is the live one; refresh materializes a new page,
+invalidation materializes a tombstone page. Staleness is computed on
+read by re-fetching the pinned source ids and comparing content
+hashes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from typing import Any
+
+from mnemo_core import results
+from mnemo_core.operations import reflect
+from mnemo_core.ports import StoragePort
+
+STANDING_CATEGORY = "_standing"
+
+
+def _page_json(
+    key: str,
+    question: str,
+    answer: str | None,
+    sources: list[dict[str, Any]],
+    *,
+    tombstone: bool = False,
+) -> str:
+    return json.dumps(
+        {
+            "page": 1,
+            "key": key,
+            "question": question,
+            "answer": answer,
+            "tombstone": tombstone,
+            "sources": sources,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+
+
+def _content_sha(text: str | None) -> str:
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def _write_page(
+    store: StoragePort,
+    subject: str | None,
+    content: str,
+) -> dict[str, Any]:
+    try:
+        page_id = store.add(
+            content=content,
+            category=STANDING_CATEGORY,
+            tags=None,
+            source=None,
+            subject=subject,
+        )
+    except ValueError as exc:
+        return results.err(results.VALIDATION, str(exc))
+    except sqlite3.Error as exc:
+        return results.err(results.STORAGE, f"standing write failed: {exc}")
+    except Exception as exc:  # noqa: BLE001 - taxonomy boundary
+        return results.err(results.INTERNAL, f"unexpected failure: {exc}")
+    return results.ok(
+        {"id": page_id, "subject": subject, "category": STANDING_CATEGORY}
+    )
+
+
+def _newest_page(
+    store: StoragePort, subject: str | None, key: str
+) -> dict[str, Any] | None:
+    """Newest-wins page lookup: latest created_at among matching rows."""
+    try:
+        rows = store.search(
+            f'"{key}"', category=STANDING_CATEGORY, limit=25, subject=subject
+        )
+    except sqlite3.Error:
+        return None
+    best: dict[str, Any] | None = None
+    best_order: tuple[str, str] = ("", "")
+    for row in rows:
+        if not isinstance(row, dict) or row.get("category") != STANDING_CATEGORY:
+            continue
+        try:
+            doc = json.loads(row.get("content") or "")
+        except (TypeError, ValueError):
+            continue
+        if isinstance(doc, dict) and doc.get("key") == key:
+            order = (str(row.get("created_at") or ""), str(row.get("id") or ""))
+            if order >= best_order:
+                best_order = order
+                best = row
+    return best
+
+
+def standing_refresh(
+    store: StoragePort,
+    subject: str | None,
+    key: str,
+    question: str,
+    k: int = 5,
+) -> dict[str, Any]:
+    """Explicitly (re)materialize the page for (subject, key) via reflect."""
+    if not key or not key.strip():
+        return results.err(results.VALIDATION, "key is required")
+    if not question or not question.strip():
+        return results.err(results.VALIDATION, "question is required")
+    reflected = reflect(store, subject, question.strip(), k=k)
+    if not reflected.get("ok"):
+        return reflected
+    data = reflected["data"]
+    sources = [
+        {"id": c.get("id"), "sha": _content_sha(c.get("content"))}
+        for c in data["citations"]
+    ]
+    content = _page_json(key.strip(), question.strip(), data["answer"], sources)
+    written = _write_page(store, subject, content)
+    if not written.get("ok"):
+        return written
+    return results.ok(
+        {
+            "id": written["data"]["id"],
+            "subject": subject,
+            "key": key.strip(),
+            "answer": data["answer"],
+            "abstained": data["abstained"],
+            "sources": sources,
+            "cost": data["cost"],
+        }
+    )
+
+
+def standing_invalidate(
+    store: StoragePort,
+    subject: str | None,
+    key: str,
+    question: str = "",
+) -> dict[str, Any]:
+    """Materialize a tombstone page; the newest-wins read reports it."""
+    if not key or not key.strip():
+        return results.err(results.VALIDATION, "key is required")
+    content = _page_json(key.strip(), question, None, [], tombstone=True)
+    written = _write_page(store, subject, content)
+    if not written.get("ok"):
+        return written
+    return results.ok(
+        {
+            "id": written["data"]["id"],
+            "subject": subject,
+            "key": key.strip(),
+            "tombstone": True,
+        }
+    )
+
+
+def standing_read(store: StoragePort, subject: str | None, key: str) -> dict[str, Any]:
+    """Cheap read: newest page + staleness verdict, no recompute."""
+    if not key or not key.strip():
+        return results.err(results.VALIDATION, "key is required")
+    row = _newest_page(store, subject, key.strip())
+    if row is None:
+        return results.err(
+            results.NOT_FOUND, f"standing page {key.strip()!r} not found"
+        )
+    try:
+        doc = json.loads(row.get("content") or "")
+    except (TypeError, ValueError):
+        return results.err(results.STORAGE, "standing page content is not valid JSON")
+    if doc.get("tombstone"):
+        return results.ok(
+            {
+                "id": row.get("id"),
+                "subject": subject,
+                "key": key.strip(),
+                "tombstone": True,
+                "answer": None,
+                "staleness": "invalidated",
+                "sources": [],
+                "cost": {"model_calls": 0, "prompt_tokens": 0, "completion_tokens": 0},
+            }
+        )
+    staleness = "fresh"
+    sources: list[dict[str, Any]] = []
+    for src in doc.get("sources", []):
+        try:
+            live = store.get(src["id"], subject=subject)
+        except sqlite3.Error as exc:
+            return results.err(results.STORAGE, f"standing read failed: {exc}")
+        except Exception as exc:  # noqa: BLE001 - taxonomy boundary
+            return results.err(results.INTERNAL, f"unexpected failure: {exc}")
+        if live is None:
+            state = "missing"
+            staleness = "stale:source_missing"
+        else:
+            changed = _content_sha(live.get("content")) != src.get("sha")
+            state = "changed" if changed else "fresh"
+            if changed:
+                staleness = "stale:content_changed"
+        sources.append({"id": src.get("id"), "state": state})
+    return results.ok(
+        {
+            "id": row.get("id"),
+            "subject": subject,
+            "key": key.strip(),
+            "tombstone": False,
+            "answer": doc.get("answer"),
+            "staleness": staleness,
+            "sources": sources,
+            "cost": {"model_calls": 0, "prompt_tokens": 0, "completion_tokens": 0},
+        }
+    )

--- a/src/mnemo_mcp/pilot_tools.py
+++ b/src/mnemo_mcp/pilot_tools.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mnemo_core import operations
+from mnemo_core import operations, standing
 from mnemo_mcp.db import MemoryDB
 
 
@@ -40,3 +40,26 @@ def pilot_fetch(db: MemoryDB, subject: str | None, args: dict[str, Any]) -> dict
 def pilot_reflect(db: MemoryDB, subject: str | None, args: dict[str, Any]) -> dict:
     """MCP tool ``pilot_reflect``: args dict in, envelope out."""
     return operations.reflect(db, subject, args.get("query", ""), k=args.get("k", 5))
+
+
+def pilot_standing_refresh(
+    db: MemoryDB, subject: str | None, args: dict[str, Any]
+) -> dict:
+    """MCP tool ``pilot_standing_refresh``: args dict in, envelope out."""
+    return standing.standing_refresh(
+        db, subject, args.get("key", ""), args.get("question", ""), k=args.get("k", 5)
+    )
+
+
+def pilot_standing_read(
+    db: MemoryDB, subject: str | None, args: dict[str, Any]
+) -> dict:
+    """MCP tool ``pilot_standing_read``: args dict in, envelope out."""
+    return standing.standing_read(db, subject, args.get("key", ""))
+
+
+def pilot_standing_invalidate(
+    db: MemoryDB, subject: str | None, args: dict[str, Any]
+) -> dict:
+    """MCP tool ``pilot_standing_invalidate``: args dict in, envelope out."""
+    return standing.standing_invalidate(db, subject, args.get("key", ""))

--- a/tests/test_mn5_eval.py
+++ b/tests/test_mn5_eval.py
@@ -1,0 +1,69 @@
+"""MN-5 eval: standing pages corpus must pass fully against the dry core."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from evals.run_mn5_standing import CORPUS_PATH, REPORT_PATH, run_eval
+
+EXPECTED_CATEGORIES = {
+    "materialize_read",
+    "abstention",
+    "subject_scope",
+    "staleness",
+    "invalidation",
+    "validation",
+}
+
+
+def test_corpus_is_wellformed() -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    ids = [c["id"] for c in corpus["cases"]]
+    assert len(ids) == len(set(ids)), "duplicate case ids"
+    assert {c["category"] for c in corpus["cases"]} == EXPECTED_CATEGORIES
+    langs = {c["lang"] for c in corpus["cases"]}
+    assert langs == {"en", "vi"}
+    gaps = " ".join(corpus["known_gaps"])
+    assert "no scheduled re-validation" in gaps and "newest-wins" in gaps
+
+
+def test_baseline_all_cases_pass(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "run")
+    assert report["total_cases"] >= 8
+    assert report["failed_cases"] == [], f"failed: {report['failed_cases']}"
+    assert report["accuracy"] == 1.0
+    assert report["paid_calls"] == 0
+    assert report["cost_usd"] == 0.0
+    assert report["per_case_stores"] is True
+
+
+def test_determinism_across_runs(tmp_path: Path) -> None:
+    first = run_eval(tmp_path / "a")
+    second = run_eval(tmp_path / "b")
+    assert first["accuracy"] == second["accuracy"]
+    assert first["passed"] == second["passed"]
+    assert first["failed_cases"] == second["failed_cases"]
+
+
+def test_scoring_detects_failure_by_tampering(tmp_path: Path) -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    for case in corpus["cases"]:
+        if case["expect"]["type"] == "standing_fresh":
+            case["expect"]["answer_contains"] = "no-such-needle-xyz"
+            break
+    tampered = tmp_path / "tampered.json"
+    tampered.write_text(json.dumps(corpus), encoding="utf-8")
+    report = run_eval(tmp_path / "run", corpus_path=tampered)
+    assert report["accuracy"] < 1.0
+    assert len(report["failed_cases"]) == 1
+
+
+def test_main_report_written(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "run")
+    out = tmp_path / "mn5_standing_baseline.json"
+    out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    saved = json.loads(out.read_text(encoding="utf-8"))
+    assert saved["deterministic"] is True
+    assert saved["known_gaps"]
+    assert REPORT_PATH.name == "mn5_standing_baseline.json"

--- a/tests/test_mn5_standing.py
+++ b/tests/test_mn5_standing.py
@@ -1,0 +1,128 @@
+"""MN-5: standing questions / knowledge pages unit tests (dry)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from mnemo_core import results, standing
+from mnemo_mcp.db import MemoryDB
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Iterator[MemoryDB]:
+    db = MemoryDB(tmp_path / "standing.db", embedding_dims=0)
+    yield db
+    db.close()
+
+
+def test_refresh_materializes_extractive_page(store: MemoryDB) -> None:
+    from mnemo_core import operations
+
+    operations.capture(store, "alice", "deploy checklist for pilot")
+    env = standing.standing_refresh(store, "alice", "deploy-page", "deploy checklist")
+    assert env["ok"] is True
+    assert env["data"]["abstained"] is False
+    assert env["data"]["cost"]["model_calls"] == 0
+    assert env["data"]["sources"], "page must pin source versions"
+
+    read = standing.standing_read(store, "alice", "deploy-page")
+    assert read["ok"] is True
+    data = read["data"]
+    assert data["tombstone"] is False
+    assert data["staleness"] == "fresh"
+    assert data["answer"] == "deploy checklist for pilot"
+    assert data["cost"] == {
+        "model_calls": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+    }
+
+
+def test_read_is_cheap_and_reports_missing_page(store: MemoryDB) -> None:
+    missing = standing.standing_read(store, "alice", "nope")
+    assert missing["ok"] is False
+    assert missing["error"]["code"] == results.NOT_FOUND
+
+
+def test_source_missing_marks_page_stale(store: MemoryDB, tmp_path: Path) -> None:
+    from mnemo_core import operations
+
+    operations.capture(store, "alice", "oncall rotation alice monday")
+    standing.standing_refresh(store, "alice", "oncall-page", "oncall rotation")
+    # The pilot tier has no delete op, but the DB layer is still SQLite:
+    # hard-delete the source row behind the store's back and the next
+    # cheap read must verdict the page stale instead of crashing.
+    conn = __import__("sqlite3").connect(tmp_path / "standing.db")
+    conn.execute("DELETE FROM memories WHERE category != '_standing'")
+    conn.commit()
+    conn.close()
+    read = standing.standing_read(store, "alice", "oncall-page")
+    assert read["ok"] is True
+    assert read["data"]["staleness"] == "stale:source_missing"
+    assert read["data"]["answer"] is not None
+
+
+def test_refresh_supersedes_older_page_newest_wins(store: MemoryDB) -> None:
+    from mnemo_core import operations
+
+    operations.capture(store, "alice", "deploy checklist v1")
+    operations.capture(store, "alice", "deploy checklist v2 rollout")
+    standing.standing_refresh(store, "alice", "deploy-page", "deploy checklist v1")
+    env = standing.standing_refresh(
+        store, "alice", "deploy-page", "checklist v2 rollout"
+    )
+    assert env["ok"] is True
+    read = standing.standing_read(store, "alice", "deploy-page")
+    assert read["ok"] is True
+    assert read["data"]["answer"] == "deploy checklist v2 rollout"
+
+
+def test_invalidate_writes_tombstone_and_read_reports_it(store: MemoryDB) -> None:
+    from mnemo_core import operations
+
+    operations.capture(store, "alice", "deploy checklist for pilot")
+    standing.standing_refresh(store, "alice", "deploy-page", "deploy checklist")
+    inv = standing.standing_invalidate(
+        store, "alice", "deploy-page", "deploy checklist"
+    )
+    assert inv["ok"] is True
+    read = standing.standing_read(store, "alice", "deploy-page")
+    assert read["ok"] is True
+    assert read["data"]["tombstone"] is True
+    assert read["data"]["staleness"] == "invalidated"
+    assert read["data"]["answer"] is None
+
+
+def test_standing_pages_respect_subject_scope(store: MemoryDB) -> None:
+    from mnemo_core import operations
+
+    operations.capture(store, "alice", "alice deploy checklist")
+    standing.standing_refresh(store, "alice", "deploy-page", "deploy checklist")
+    bob = standing.standing_read(store, "bob", "deploy-page")
+    assert bob["ok"] is False
+    assert bob["error"]["code"] == results.NOT_FOUND
+
+
+def test_standing_validates_inputs(store: MemoryDB) -> None:
+    no_key = standing.standing_refresh(store, "alice", "  ", "question")
+    assert no_key["error"]["code"] == results.VALIDATION
+    no_question = standing.standing_refresh(store, "alice", "key", "  ")
+    assert no_question["error"]["code"] == results.VALIDATION
+    no_key_read = standing.standing_read(store, "alice", "")
+    assert no_key_read["error"]["code"] == results.VALIDATION
+    no_key_inv = standing.standing_invalidate(store, "alice", "")
+    assert no_key_inv["error"]["code"] == results.VALIDATION
+
+
+def test_refresh_abstaining_question_materializes_empty_page(store: MemoryDB) -> None:
+    env = standing.standing_refresh(store, "alice", "empty-page", "nothing known")
+    assert env["ok"] is True
+    assert env["data"]["abstained"] is True
+    assert env["data"]["sources"] == []
+    read = standing.standing_read(store, "alice", "empty-page")
+    assert read["ok"] is True
+    assert read["data"]["staleness"] == "fresh"
+    assert read["data"]["answer"] is None

--- a/tests/test_mnemo_pilot_equivalence.py
+++ b/tests/test_mnemo_pilot_equivalence.py
@@ -89,6 +89,46 @@ SCENARIOS: list[tuple[str, dict[str, Any]]] = [
             "seed": [{"content": "deploy checklist for pilot", "tags": ["ops"]}],
         },
     ),
+    ("standing-refresh", {"key": "   "}),  # VALIDATION
+    ("standing-refresh", {"key": "dp", "question": "deploy checklist"}),  # abstain page
+    (
+        "standing-refresh",
+        {
+            "key": "dp",
+            "question": "deploy checklist",
+            "seed": [
+                {"content": "deploy checklist for pilot", "tags": ["ops"]},
+                {"op": "standing-refresh", "key": "dp", "question": "deploy checklist"},
+            ],
+        },
+    ),  # supersede: second refresh over the first
+    ("standing-read", {"key": "ghost"}),  # NOT_FOUND
+    (
+        "standing-read",
+        {
+            "key": "dp",
+            "seed": [
+                {"content": "deploy checklist for pilot", "tags": ["ops"]},
+                {"op": "standing-refresh", "key": "dp", "question": "deploy checklist"},
+            ],
+        },
+    ),
+    ("standing-invalidate", {"key": "   "}),  # VALIDATION
+    (
+        "standing-read",
+        {
+            "key": "dp",
+            "seed": [
+                {"content": "deploy checklist for pilot", "tags": ["ops"]},
+                {"op": "standing-refresh", "key": "dp", "question": "deploy checklist"},
+                {
+                    "op": "standing-invalidate",
+                    "key": "dp",
+                    "question": "deploy checklist",
+                },
+            ],
+        },
+    ),  # tombstone
 ]
 
 _HANDLERS = {
@@ -96,7 +136,36 @@ _HANDLERS = {
     "recall": pilot_tools.pilot_recall,
     "fetch": pilot_tools.pilot_fetch,
     "reflect": pilot_tools.pilot_reflect,
+    "standing-refresh": pilot_tools.pilot_standing_refresh,
+    "standing-read": pilot_tools.pilot_standing_read,
+    "standing-invalidate": pilot_tools.pilot_standing_invalidate,
 }
+
+
+def _seed_cli_args(seed: dict[str, Any], cli_db: Path) -> list[str]:
+    """CLI argv for one seed op (options belong to each subparser)."""
+    op = seed.get("op", "capture")
+    base = ["--db", str(cli_db), "--subject", "alice"]
+    if op == "capture":
+        argv = ["capture", *base, seed["content"]]
+        if "tags" in seed:
+            argv += ["--tags", ",".join(seed["tags"])]
+        return argv
+    if op == "standing-refresh":
+        return ["standing-refresh", *base, seed["key"], seed["question"]]
+    if op == "standing-invalidate":
+        return ["standing-invalidate", *base, seed["key"]]
+    raise ValueError(f"unsupported seed op: {op}")
+
+
+def _seed_mcp_env(seed: dict[str, Any], mcp_store: MemoryDB) -> dict:
+    op = seed.get("op", "capture")
+    handler = {
+        "capture": pilot_tools.pilot_capture,
+        "standing-refresh": pilot_tools.pilot_standing_refresh,
+        "standing-invalidate": pilot_tools.pilot_standing_invalidate,
+    }[op]
+    return handler(mcp_store, "alice", seed)
 
 
 def test_cli_and_mcp_envelopes_are_byte_equal(
@@ -110,17 +179,9 @@ def test_cli_and_mcp_envelopes_are_byte_equal(
         mcp_store = MemoryDB(tmp_path / f"mcp-{i}.db", embedding_dims=0)
         cli_args: list[str] = ["--db", str(cli_db), "--subject", "alice"]
         for seed in args.get("seed", []):
-            seed_args = [
-                "capture",
-                "--db",
-                str(cli_db),
-                "--subject",
-                "alice",
-                seed["content"],
-            ]
-            seed_out, seed_code = _run_cli(seed_args, capsys)
+            seed_out, seed_code = _run_cli(_seed_cli_args(seed, cli_db), capsys)
             assert seed_code == 0, seed_out
-            mcp_seed = pilot_tools.pilot_capture(mcp_store, "alice", seed)
+            mcp_seed = _seed_mcp_env(seed, mcp_store)
             assert mcp_seed["ok"] is True, mcp_seed
         if op == "capture":
             cli_args += [args["content"]]
@@ -132,6 +193,15 @@ def test_cli_and_mcp_envelopes_are_byte_equal(
             cli_args += [args["query"], "--k", str(args.get("k", 5))]
         elif op == "reflect":
             cli_args += [args["query"], "--k", str(args.get("k", 5))]
+        elif op == "standing-refresh":
+            cli_args += [
+                args["key"],
+                args.get("question", ""),
+                "--k",
+                str(args.get("k", 5)),
+            ]
+        elif op in ("standing-read", "standing-invalidate"):
+            cli_args += [args["key"]]
         else:
             cli_args += [args["memory_id"]]
 


### PR DESCRIPTION
MN-5 of the mnemo pilot (P5, dry tier). A standing page materializes a reflect answer with pinned source versions (sha256 per source) as a memory row in category _standing - no schema migration. Newest-wins supersede (pilot has no update); invalidation = tombstone page. standing_read is cheap (no recompute, zero cost receipt) and verdicts staleness on read (source_missing / content_changed). Explicit refresh only, no scheduled sync. Surfaces: CLI standing-refresh/read/invalidate + pilot_standing_* handlers. Equivalence gate extended (VALIDATION, abstain page, supersede, NOT_FOUND, tombstone - byte-equal both surfaces). MN-5 eval: 8-case deterministic corpus, accuracy 1.0, paid_calls 0.