### PR TITLE
fix: pin better-semantic-release action to v1.6.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
       # BEFORE the real run creates a git tag or GitHub Release. Same action + SHA and
       # same prerelease inputs as the real step, run against the same untouched checkout,
       # so the computed version is identical.
-      - uses: n24q02m/better-semantic-release@69319fae1169b6ee7b89565c7b54b55d1531d42e # v1.6.0
+      - uses: n24q02m/better-semantic-release@6e6884898bfe1ac34a0bc64ed62f54a21562df23 # v1.6.1
         id: dryrun
         with:
           github_token: ${{ steps.app-token.outputs.token }}
@@ -122,7 +122,7 @@ jobs:
           echo "::error::Could not verify whether ${PKG} ${COMPUTED_VERSION} exists on PyPI: ${URL} returned HTTP '${status:-<no response>}' (expected 200 or 404). Refusing to proceed so a genuine collision cannot slip through as a false 'free'. Re-run the release once the registry is reachable."
           exit 1
 
-      - uses: n24q02m/better-semantic-release@69319fae1169b6ee7b89565c7b54b55d1531d42e # v1.6.0
+      - uses: n24q02m/better-semantic-release@6e6884898bfe1ac34a0bc64ed62f54a21562df23 # v1.6.1
         id: release
         with:
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Bumps the `n24q02m/better-semantic-release` action pin from `69319fae1169b6ee7b89565c7b54b55d1531d42e` (`v1.6.0`) to `6e6884898bfe1ac34a0bc64ed62f54a21562df23` (v1.6.1 release commit).

- File: `.github/workflows/cd.yml` (2 pin lines)
- Audit-recovery wave W8, plan P2b
- This wave only opens PRs; repo CI validates this change.