### PR TITLE
feat: mn6 multilingual + public domain eval, hosted-runner timeout fix

### DIFF
--- a/evals/mn6_multilingual_baseline.json
+++ b/evals/mn6_multilingual_baseline.json
@@ -1,0 +1,19 @@
+{
+  "corpus": "mn6-eval-multilingual",
+  "corpus_version": 1,
+  "deterministic": true,
+  "paid_calls": 0,
+  "cost_usd": 0.0,
+  "per_case_stores": true,
+  "total_cases": 10,
+  "passed": 10,
+  "failed_cases": [],
+  "accuracy": 1.0,
+  "latency_ms_mean": 0.718,
+  "latency_ms_p95": 0.838,
+  "known_gaps": [
+    "FTS5 diacritic folding is asymmetric: multi-word non-diacritic queries match diacritic content, but a single non-diacritic token does not match its diacritic form (pinned as absent_all, not scored as failure)",
+    "retrieval is lexical (FTS5); no semantic fallback without embeddings in the dry tier",
+    "public domain access is subject=None (legacy/unscoped rows) through the same scoped surfaces; no HTTP/SDK surface - CLI/API per P6"
+  ]
+}

--- a/evals/mn6_multilingual_corpus.json
+++ b/evals/mn6_multilingual_corpus.json
@@ -1,0 +1,112 @@
+{
+  "name": "mn6-eval-multilingual",
+  "version": 1,
+  "known_gaps": [
+    "FTS5 diacritic folding is asymmetric: multi-word non-diacritic queries match diacritic content, but a single non-diacritic token does not match its diacritic form (pinned as absent_all, not scored as failure)",
+    "retrieval is lexical (FTS5); no semantic fallback without embeddings in the dry tier",
+    "public domain access is subject=None (legacy/unscoped rows) through the same scoped surfaces; no HTTP/SDK surface - CLI/API per P6"
+  ],
+  "cases": [
+    {
+      "id": "mn6-vi-roundtrip-diacritics",
+      "lang": "vi",
+      "category": "vi_roundtrip",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "Hồ Gươm nằm ở quận Hoàn Kiếm, Hà Nội"}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "Hồ Gươm", "k": 5}},
+      "expect": {"type": "contains", "needle": "Hoàn Kiếm"}
+    },
+    {
+      "id": "mn6-vi-entity-native",
+      "lang": "vi",
+      "category": "vi_roundtrip",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "Nguyễn Du viết Truyện Kiều đầu thế kỷ 19"}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "Nguyễn Du", "k": 5}},
+      "expect": {"type": "contains", "needle": "Truyện Kiều"}
+    },
+    {
+      "id": "mn6-vi-query-no-diacritics-two-words",
+      "lang": "vi",
+      "category": "diacritic_folding",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "Hồ Gươm nằm ở quận Hoàn Kiếm, Hà Nội"}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "ho guom", "k": 5}},
+      "expect": {"type": "contains", "needle": "Hồ Gươm"}
+    },
+    {
+      "id": "mn6-vi-single-token-no-diacritics",
+      "lang": "vi",
+      "category": "diacritic_folding",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "Nguyễn Du viết Truyện Kiều"}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "kieu", "k": 5}},
+      "expect": {"type": "absent_all"}
+    },
+    {
+      "id": "mn6-mixed-vi-en-content",
+      "lang": "vi",
+      "category": "vi_roundtrip",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "Deploy checklist server Hà Nội: backup DB trước khi restart"}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "checklist Hà Nội", "k": 5}},
+      "expect": {"type": "contains", "needle": "backup DB"}
+    },
+    {
+      "id": "mn6-vi-reflect-extractive",
+      "lang": "vi",
+      "category": "vi_reflect",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "ghi chú họp ngày mai lúc 9 giờ với nhóm pilot"}}
+      ],
+      "probe": {"op": "reflect", "subject": "alice", "args": {"query": "họp ngày mai", "k": 5}},
+      "expect": {"type": "reflect_answer_contains", "needle": "họp ngày mai lúc 9 giờ"}
+    },
+    {
+      "id": "mn6-vi-standing-page",
+      "lang": "vi",
+      "category": "vi_standing",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "mật khẩu wifi văn phòng là chuột đồng câu hỏi bảo mật"}},
+        {"op": "standing_refresh", "subject": "alice", "args": {"key": "wifi-page", "question": "wifi văn phòng"}}
+      ],
+      "probe": {"op": "standing_read", "subject": "alice", "args": {"key": "wifi-page"}},
+      "expect": {"type": "standing_fresh", "answer_contains": "mật khẩu wifi"}
+    },
+    {
+      "id": "mn6-vi-subject-isolation",
+      "lang": "vi",
+      "category": "public_domain",
+      "setup": [
+        {"op": "capture", "subject": "alice", "args": {"content": "ghi chú riêng của alice về hợp đồng"}}
+      ],
+      "probe": {"op": "recall", "subject": "bob", "args": {"query": "hợp đồng", "k": 5}},
+      "expect": {"type": "absent_all"}
+    },
+    {
+      "id": "mn6-public-domain-null-subject-visible-unscoped",
+      "lang": "vi",
+      "category": "public_domain",
+      "setup": [
+        {"op": "capture", "subject": null, "args": {"content": "thông báo công khai: bảo trì hệ thống chủ nhật"}}
+      ],
+      "probe": {"op": "recall", "subject": null, "args": {"query": "bảo trì công khai", "k": 5}},
+      "expect": {"type": "contains", "needle": "bảo trì hệ thống"}
+    },
+    {
+      "id": "mn6-public-domain-invisible-to-scoped",
+      "lang": "vi",
+      "category": "public_domain",
+      "setup": [
+        {"op": "capture", "subject": null, "args": {"content": "thông báo công khai: bảo trì hệ thống chủ nhật"}}
+      ],
+      "probe": {"op": "recall", "subject": "alice", "args": {"query": "bảo trì", "k": 5}},
+      "expect": {"type": "absent_all"}
+    }
+  ]
+}

--- a/evals/run_mn6_multilingual.py
+++ b/evals/run_mn6_multilingual.py
@@ -1,0 +1,133 @@
+"""MN-6 eval runner: multilingual + public domain access (dry).
+
+Mirrors the MN-1/4/5 runner contracts: one fresh DB per case;
+deterministic scoring (exact substring membership, absence, abstention
+flags, staleness verdicts, taxonomy codes). The diacritic-folding
+behavior is PINNED as observed from the FTS5 backend, including the
+asymmetric single-token gap recorded in ``known_gaps``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from mnemo_core import operations, standing
+from mnemo_mcp.db import MemoryDB
+
+CORPUS_PATH = Path(__file__).with_name("mn6_multilingual_corpus.json")
+REPORT_PATH = Path(__file__).with_name("mn6_multilingual_baseline.json")
+
+_ZERO_COST = {"model_calls": 0, "prompt_tokens": 0, "completion_tokens": 0}
+
+
+def _run_op(db: MemoryDB, op: dict[str, Any]) -> dict[str, Any]:
+    name, subject, args = op["op"], op["subject"], dict(op.get("args", {}))
+    if name == "capture":
+        return operations.capture(
+            db,
+            subject,
+            args["content"],
+            tags=args.get("tags"),
+            category=args.get("category", "general"),
+            source=args.get("source"),
+        )
+    if name == "recall":
+        return operations.recall(db, subject, args["query"], k=args.get("k", 5))
+    if name == "reflect":
+        return operations.reflect(db, subject, args["query"], k=args.get("k", 5))
+    if name == "standing_refresh":
+        return standing.standing_refresh(
+            db, subject, args["key"], args["question"], k=args.get("k", 5)
+        )
+    if name == "standing_read":
+        return standing.standing_read(db, subject, args["key"])
+    raise ValueError(f"unknown op: {name}")
+
+
+def _check(expect: dict[str, Any], envelope: dict[str, Any]) -> tuple[bool, str | None]:
+    etype = expect["type"]
+    if etype == "contains":
+        if not envelope.get("ok"):
+            return False, "envelope not ok"
+        matches = [m["content"] for m in envelope["data"]["matches"]]
+        return any(expect["needle"] in c for c in matches), None
+    if etype == "absent_all":
+        if not envelope.get("ok"):
+            return False, "envelope not ok"
+        return len(envelope["data"]["matches"]) == 0, None
+    if etype == "reflect_answer_contains":
+        if not envelope.get("ok"):
+            return False, "envelope not ok"
+        data = envelope["data"]
+        if data["abstained"] is not False or not data["citations"]:
+            return False, "unexpected abstention"
+        if data["cost"] != _ZERO_COST:
+            return False, "non-zero cost receipt"
+        return expect["needle"] in (data["answer"] or ""), None
+    if etype == "standing_fresh":
+        if not envelope.get("ok"):
+            return False, "envelope not ok"
+        data = envelope["data"]
+        if data.get("staleness") != "fresh" or data.get("tombstone"):
+            return False, f"state {data.get('staleness')!r}"
+        return expect["answer_contains"] in (data.get("answer") or ""), None
+    raise ValueError(f"unknown expectation: {etype}")
+
+
+def run_eval(run_dir: Path, corpus_path: Path = CORPUS_PATH) -> dict[str, Any]:
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    for case in corpus["cases"]:
+        db = MemoryDB(run_dir / f"{case['id']}.db", embedding_dims=0)
+        try:
+            for step in case["setup"]:
+                env = _run_op(db, step)
+                if not env.get("ok"):
+                    raise RuntimeError(f"{case['id']}: setup failed: {env}")
+            t0 = time.perf_counter()
+            envelope = _run_op(db, case["probe"])
+            latency_ms = (time.perf_counter() - t0) * 1000.0
+        finally:
+            db.close()
+        passed, why = _check(case["expect"], envelope)
+        row: dict[str, Any] = {
+            "id": case["id"],
+            "lang": case["lang"],
+            "passed": passed,
+            "latency_ms": latency_ms,
+        }
+        if why:
+            row["why"] = why
+        rows.append(row)
+    latencies = [r["latency_ms"] for r in rows]
+    failed = [r["id"] for r in rows if not r["passed"]]
+    return {
+        "corpus": corpus["name"],
+        "corpus_version": corpus["version"],
+        "deterministic": True,
+        "paid_calls": 0,
+        "cost_usd": 0.0,
+        "per_case_stores": True,
+        "total_cases": len(rows),
+        "passed": len(rows) - len(failed),
+        "failed_cases": failed,
+        "accuracy": (len(rows) - len(failed)) / len(rows) if rows else 0.0,
+        "latency_ms_mean": round(sum(latencies) / len(latencies), 3),
+        "latency_ms_p95": round(sorted(latencies)[int(0.95 * (len(latencies) - 1))], 3),
+        "known_gaps": corpus["known_gaps"],
+    }
+
+
+def main() -> int:  # pragma: no cover
+    report = run_eval(Path(__file__).parent / "mn6_run")
+    REPORT_PATH.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0 if report["accuracy"] == 1.0 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -59,6 +59,12 @@ from mnemo_mcp.db_cf import (
 )
 from mnemo_mcp.exceptions import EmbeddingModelMismatch
 
+# Hosted-runner intervention (2026-09-11): the migration-executescript
+# fixtures (``d1_conn``) hit the global 30s per-test budget on GitHub
+# windows runners five times in one day while local runs finish in
+# seconds. Give every test in this file its own larger budget.
+pytestmark = pytest.mark.timeout(120)
+
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 _MIGRATION = _REPO_ROOT / "migrations" / "0001_init.sql"
 _MIGRATION_2 = _REPO_ROOT / "migrations" / "0002_per_sub_isolation.sql"

--- a/tests/test_db_cf_vectors.py
+++ b/tests/test_db_cf_vectors.py
@@ -61,6 +61,12 @@ from mnemo_mcp.db_cf import (
 )
 from mnemo_mcp.exceptions import EmbeddingModelMismatch
 
+# Hosted-runner intervention (2026-09-11): the migration-executescript
+# fixtures (``fake_worker``) hit the global 30s per-test budget on
+# GitHub windows runners repeatedly while local runs finish in seconds.
+# Give every test in this file its own larger budget.
+pytestmark = pytest.mark.timeout(120)
+
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 _MIGRATION = _REPO_ROOT / "migrations" / "0001_init.sql"
 _MIGRATION_2 = _REPO_ROOT / "migrations" / "0002_per_sub_isolation.sql"

--- a/tests/test_mn6_eval.py
+++ b/tests/test_mn6_eval.py
@@ -1,0 +1,65 @@
+"""MN-6 eval: multilingual + public domain corpus must pass fully."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from evals.run_mn6_multilingual import CORPUS_PATH, REPORT_PATH, run_eval
+
+EXPECTED_CATEGORIES = {
+    "vi_roundtrip",
+    "diacritic_folding",
+    "vi_reflect",
+    "vi_standing",
+    "public_domain",
+}
+
+
+def test_corpus_is_wellformed() -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    ids = [c["id"] for c in corpus["cases"]]
+    assert len(ids) == len(set(ids)), "duplicate case ids"
+    assert {c["category"] for c in corpus["cases"]} == EXPECTED_CATEGORIES
+    assert all(c["lang"] == "vi" for c in corpus["cases"])
+    gaps = " ".join(corpus["known_gaps"])
+    assert "single non-diacritic token" in gaps and "no HTTP/SDK" in gaps
+
+
+def test_baseline_all_cases_pass(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "run")
+    assert report["total_cases"] >= 10
+    assert report["failed_cases"] == [], f"failed: {report['failed_cases']}"
+    assert report["accuracy"] == 1.0
+    assert report["paid_calls"] == 0
+    assert report["cost_usd"] == 0.0
+    assert report["per_case_stores"] is True
+
+
+def test_diacritic_gap_is_pinned_not_failed(tmp_path: Path) -> None:
+    corpus = json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+    gap_cases = [c for c in corpus["cases"] if c["category"] == "diacritic_folding"]
+    assert len(gap_cases) == 2
+    folding = {c["id"]: c["expect"]["type"] for c in gap_cases}
+    assert folding["mn6-vi-query-no-diacritics-two-words"] == "contains"
+    assert folding["mn6-vi-single-token-no-diacritics"] == "absent_all"
+    report = run_eval(tmp_path / "run")
+    assert report["accuracy"] == 1.0, "pinned gap must still pass"
+
+
+def test_determinism_across_runs(tmp_path: Path) -> None:
+    first = run_eval(tmp_path / "a")
+    second = run_eval(tmp_path / "b")
+    assert first["accuracy"] == second["accuracy"]
+    assert first["passed"] == second["passed"]
+    assert first["failed_cases"] == second["failed_cases"]
+
+
+def test_main_report_written(tmp_path: Path) -> None:
+    report = run_eval(tmp_path / "run")
+    out = tmp_path / "mn6_multilingual_baseline.json"
+    out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    saved = json.loads(out.read_text(encoding="utf-8"))
+    assert saved["deterministic"] is True
+    assert saved["known_gaps"]
+    assert REPORT_PATH.name == "mn6_multilingual_baseline.json"

--- a/tests/test_mnemo_pilot_equivalence.py
+++ b/tests/test_mnemo_pilot_equivalence.py
@@ -89,6 +89,18 @@ SCENARIOS: list[tuple[str, dict[str, Any]]] = [
             "seed": [{"content": "deploy checklist for pilot", "tags": ["ops"]}],
         },
     ),
+    (
+        "capture",
+        {"content": "Hồ Gươm nằm ở quận Hoàn Kiếm, Hà Nội", "tags": ["vi"]},
+    ),
+    ("recall", {"query": "Hồ Gươm", "k": 5}),
+    (
+        "reflect",
+        {
+            "query": "họp ngày mai",
+            "seed": [{"content": "ghi chú họp ngày mai lúc 9 giờ"}],
+        },
+    ),
     ("standing-refresh", {"key": "   "}),  # VALIDATION
     ("standing-refresh", {"key": "dp", "question": "deploy checklist"}),  # abstain page
     (


### PR DESCRIPTION
MN-6 (P6, dry): 10-case deterministic eval pinning VN-diacritics behavior (round-trips, native entities, the pinned FTS5 folding asymmetry - single non-diacritic token misses, recorded as known gap), mixed vi/en, vi reflect + standing page, and subject=None public-domain access (visible unscoped, invisible to scoped reads). No HTTP/SDK - CLI/API per P6. Accuracy 1.0, paid_calls 0. Also: module-level timeout(120) for the two migration-fixture suites (5 hosted-windows timeouts today; local seconds). Equivalence gate: vi scenarios byte-equal both surfaces.