### PR TITLE
fix: align reflect default model with the pinned manifest chain

### DIFF
--- a/evals/run_mn4_paid.py
+++ b/evals/run_mn4_paid.py
@@ -1,7 +1,9 @@
 """MN-4 paid eval runner: bounded cited reflect through a real provider.
 
 Runs the MN-4 corpus with a live ``BoundedReflectProvider`` (Cohere
-command-r7b-12-2024 via the Cloudflare AI Gateway OpenRouter route) and
+the manifest-pinned free chain (default ``openrouter/minimax/minimax-m3:free``)
+via the Cloudflare AI Gateway OpenRouter route; paid Cohere comparisons run with
+``MNEMO_REFLECT_MODEL=cohere/command-r-08-2024`` overrides) and
 scores the corpus contract on the PAID path:
 
 - ``reflect_answer_contains``: exactly one model call, complete receipt, and
@@ -30,7 +32,7 @@ from mnemo_mcp.providers import BoundedReflectProvider
 
 CORPUS_PATH = Path(__file__).parent / "mn4_reflect_corpus.json"
 REPORT_PATH = Path(__file__).parent / "mn4_paid_baseline.json"
-MODEL = os.getenv("MNEMO_REFLECT_MODEL", "cohere/command-r7b-12-2024")
+MODEL = os.getenv("MNEMO_REFLECT_MODEL", "openrouter/minimax/minimax-m3:free")
 
 
 def _provider() -> BoundedReflectProvider:

--- a/src/mnemo_cli/__main__.py
+++ b/src/mnemo_cli/__main__.py
@@ -115,7 +115,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 else:
                     provider = BoundedReflectProvider(
                         model=os.getenv(
-                            "MNEMO_REFLECT_MODEL", "cohere/command-r-08-2024"
+                            "MNEMO_REFLECT_MODEL", "openrouter/minimax/minimax-m3:free"
                         ),
                         api_key=api_key,
                         api_base=api_base,


### PR DESCRIPTION
fix: align reflect default model with the pinned manifest chain

The MN-4 paid reflect PR (#1218) shipped `cohere/command-r-08-2024` as the
CLI/eval default, reflecting the trial that produced the 12/12 baseline.
Per the mcp-secret-routing manifest the sanctioned completion chain is
`openrouter/minimax/minimax-m3:free` (Cohere is embed/rerank only); this
reverts both defaults to that chain, keeping every paid model available via
the existing `MNEMO_REFLECT_MODEL` / `--model` overrides and the price
table entries added in #1218 (r7b 0.0375/0.15, command-r 0.15/0.60,
minimax free 0/0).

Contract deviation remains receipted in
.private superpower/mcp-stack/evidence/mn4-paid-reflect-trial-2026-09-12.json
(follow-through row: revert chosen; adding Cohere completion models to the
manifest stays a governance-round question). Paid trial evidence and the
12/12 command-r baseline are unchanged and historical.

Tests: mn4 stub suite 8/8 green; ruff/ty/format clean.
